### PR TITLE
added one command

### DIFF
--- a/00_Intro/bedrock_boto3_setup.ipynb
+++ b/00_Intro/bedrock_boto3_setup.ipynb
@@ -38,6 +38,7 @@
    "outputs": [],
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
+    "%%pip install wheel\n",
     "%pip install --force-reinstall \\\n",
     "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
     "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",

--- a/00_Intro/bedrock_boto3_setup.ipynb
+++ b/00_Intro/bedrock_boto3_setup.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
-    "%%pip install wheel\n",
+    "%pip install wheel\n",
     "%pip install --force-reinstall \\\n",
     "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
     "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",


### PR DESCRIPTION
*Issue #, if available:*
```
Collecting PyYAML<5.5,>=3.10 (from awscli==1.27.162)
  Using cached PyYAML-5.4.1.tar.gz (175 kB)
  Installing build dependencies ...   Getting requirements to build wheel ... error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [68 lines of output]
      /private/var/folders/pl/lnlf1yb50tgdq9yv0tkmsnph0000gn/T/pip-build-env-cei48ddv/overlay/lib/python3.11/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
      !!
      
              ********************************************************************************
              The license_file parameter is deprecated, use license_files instead.
      
              By 2023-Oct-30, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.
      
...
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
Note: you may need to restart the kernel to use updated packages.
```

I think this issue is similar to the submitted issue https://github.com/aws-samples/amazon-bedrock-workshop/issues/7
*Description of changes:*
Just added this command `pip install wheel` before start installing `boto3` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
