### PR TITLE
Fix cpython install issues and upgrade to DataSci v3 kernel

### DIFF
--- a/00_Intro/bedrock_boto3_setup.ipynb
+++ b/00_Intro/bedrock_boto3_setup.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Amazon Bedrock boto3 Setup\n",
     "\n",
-    "> *This notebook should work well with the **`Data Science 2.0`** kernel in SageMaker Studio*\n",
+    "> *This notebook should work well with the **`Data Science 3.0`** kernel in SageMaker Studio*\n",
     "\n",
     "---\n",
     "\n",
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
-    "%pip install --force-reinstall \\\n",
+    "%pip install --no-build-isolation --force-reinstall \\\n",
     "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
     "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
     "    ../dependencies/botocore-1.29.162-py3-none-any.whl"
@@ -1287,9 +1287,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science 2.0)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-38"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1301,7 +1301,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/01_Generation/00_generate_w_bedrock.ipynb
+++ b/01_Generation/00_generate_w_bedrock.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# Invoke Bedrock model for text generation using zero-shot prompt\n",
     "\n",
-    "> *This notebook should work well with the **`Data Science 2.0`** kernel in SageMaker Studio*"
+    "> *This notebook should work well with the **`Data Science 3.0`** kernel in SageMaker Studio*"
    ]
   },
   {
@@ -67,7 +67,7 @@
    "outputs": [],
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
-    "%pip install --force-reinstall \\\n",
+    "%pip install --no-build-isolation --force-reinstall \\\n",
     "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
     "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
     "    ../dependencies/botocore-1.29.162-py3-none-any.whl\n",
@@ -891,9 +891,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science 2.0)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-38"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -905,7 +905,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/01_Generation/01_zero_shot_generation.ipynb
+++ b/01_Generation/01_zero_shot_generation.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Invoke Bedrock model using LangChain and a zero-shot prompt\n",
     "\n",
-    "> *This notebook should work well with the **`Data Science 2.0`** kernel in SageMaker Studio*"
+    "> *This notebook should work well with the **`Data Science 3.0`** kernel in SageMaker Studio*"
    ]
   },
   {
@@ -59,11 +59,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "378c827b-802f-4e4c-8a4f-ab945d68e089",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
-    "%pip install --force-reinstall \\\n",
+    "%pip install --no-build-isolation --force-reinstall \\\n",
     "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
     "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
     "    ../dependencies/botocore-1.29.162-py3-none-any.whl\n",
@@ -799,9 +801,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science 2.0)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-38"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -813,7 +815,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/01_Generation/02_contextual_generation.ipynb
+++ b/01_Generation/02_contextual_generation.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# Bedrock with LangChain using a Prompt that includes Context\n",
     "\n",
-    "> *This notebook should work well with the **`Data Science 2.0`** kernel in SageMaker Studio*"
+    "> *This notebook should work well with the **`Data Science 3.0`** kernel in SageMaker Studio*"
    ]
   },
   {
@@ -73,7 +73,7 @@
    "outputs": [],
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
-    "%pip install --force-reinstall \\\n",
+    "%pip install --no-build-isolation --force-reinstall \\\n",
     "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
     "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
     "    ../dependencies/botocore-1.29.162-py3-none-any.whl\n",
@@ -85,7 +85,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "558a9372-0789-414a-a1d7-2976056f2015",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import json\n",
@@ -191,7 +193,6 @@
     "    template=\"\"\"Create an apology email from the Service Manager {customerServiceManager} to {customerName}. \n",
     "   in response to the following feedback that was received from the customer: {feedbackFromCustomer}.\n",
     "   \"\"\"\n",
-    "    \n",
     ")\n",
     "\n",
     "# Pass in values to the input variables\n",
@@ -240,7 +241,7 @@
    "source": [
     "response = textgen_llm(prompt)\n",
     "\n",
-    "email = response[response.index('\\n')+1:]  \n",
+    "email = response[response.index('\\n')+1:]\n",
     "\n",
     "print_ww(email)"
    ]
@@ -834,9 +835,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science 2.0)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-38"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -848,7 +849,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/02_Summarization/01.small-text-summarization-claude.ipynb
+++ b/02_Summarization/01.small-text-summarization-claude.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Text summarization with small files with Anthropic Claude\n",
     "\n",
-    "> *This notebook should work well with the **`Data Science 2.0`** kernel in SageMaker Studio*"
+    "> *This notebook should work well with the **`Data Science 3.0`** kernel in SageMaker Studio*"
    ]
   },
   {
@@ -60,7 +60,7 @@
    "outputs": [],
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
-    "%pip install --force-reinstall \\\n",
+    "%pip install --no-build-isolation --force-reinstall \\\n",
     "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
     "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
     "    ../dependencies/botocore-1.29.162-py3-none-any.whl\n",
@@ -894,9 +894,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science 2.0)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-38"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -908,7 +908,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/02_Summarization/01.small-text-summarization-titan.ipynb
+++ b/02_Summarization/01.small-text-summarization-titan.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Text summarization with small files with Amazon Titan\n",
     "\n",
-    "> *This notebook should work well with the **`Data Science 2.0`** kernel in SageMaker Studio*"
+    "> *This notebook should work well with the **`Data Science 3.0`** kernel in SageMaker Studio*"
    ]
   },
   {
@@ -59,7 +59,7 @@
    "outputs": [],
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
-    "%pip install --force-reinstall \\\n",
+    "%pip install --no-build-isolation --force-reinstall \\\n",
     "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
     "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
     "    ../dependencies/botocore-1.29.162-py3-none-any.whl\n",
@@ -898,9 +898,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science 2.0)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-38"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -912,7 +912,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/02_Summarization/02.long-text-summarization-titan.ipynb
+++ b/02_Summarization/02.long-text-summarization-titan.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Abstractive Text Summarization with Amazon Titan\n",
     "\n",
-    "> *This notebook should work well with the **`Data Science 2.0`** kernel in SageMaker Studio*"
+    "> *This notebook should work well with the **`Data Science 3.0`** kernel in SageMaker Studio*"
    ]
   },
   {
@@ -60,7 +60,7 @@
    "outputs": [],
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
-    "%pip install --force-reinstall \\\n",
+    "%pip install --no-build-isolation --force-reinstall \\\n",
     "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
     "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
     "    ../dependencies/botocore-1.29.162-py3-none-any.whl\n",
@@ -865,9 +865,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science 2.0)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-38"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -879,7 +879,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/03_QuestionAnswering/00_qa_w_bedrock_titan.ipynb
+++ b/03_QuestionAnswering/00_qa_w_bedrock_titan.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Question and answers with Bedrock\n",
     "\n",
-    "> *This notebook should work well with the **`Data Science 2.0`** kernel in SageMaker Studio*\n",
+    "> *This notebook should work well with the **`Data Science 3.0`** kernel in SageMaker Studio*\n",
     "\n",
     "Question Answering (QA) is an important task that involves extracting answers to factual queries posed in natural language. Typically, a QA system processes a query against a knowledge base containing structured or unstructured data and generates a response with accurate information. Ensuring high accuracy is key to developing a useful, reliable and trustworthy question answering system, especially for enterprise use cases. \n",
     "\n",
@@ -44,7 +44,7 @@
    "outputs": [],
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
-    "%pip install --force-reinstall \\\n",
+    "%pip install --no-build-isolation --force-reinstall \\\n",
     "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
     "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
     "    ../dependencies/botocore-1.29.162-py3-none-any.whl\n",
@@ -981,9 +981,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science 2.0)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-38"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -995,7 +995,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/03_QuestionAnswering/01_qa_w_rag_claude.ipynb
+++ b/03_QuestionAnswering/01_qa_w_rag_claude.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Retrieval Augmented Question & Answering with Amazon Bedrock using LangChain\n",
     "\n",
-    "> *This notebook should work well with the **`Data Science 2.0`** kernel in SageMaker Studio*"
+    "> *This notebook should work well with the **`Data Science 3.0`** kernel in SageMaker Studio*"
    ]
   },
   {
@@ -113,7 +113,7 @@
    "outputs": [],
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
-    "%pip install --force-reinstall \\\n",
+    "%pip install --no-build-isolation --force-reinstall \\\n",
     "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
     "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
     "    ../dependencies/botocore-1.29.162-py3-none-any.whl\n",
@@ -1084,9 +1084,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science 2.0)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-38"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1098,7 +1098,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/04_Chatbot/00_Chatbot_AI21.ipynb
+++ b/04_Chatbot/00_Chatbot_AI21.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Conversational Interface - Chatbot with AI21 LLM\n",
     "\n",
-    "> *This notebook should work well with the **`Data Science 2.0`** kernel in SageMaker Studio*\n",
+    "> *This notebook should work well with the **`Data Science 3.0`** kernel in SageMaker Studio*\n",
     "\n",
     "In this notebook, we will build a chatbot using the Foundational Models (FMs) in Amazon Bedrock. For our use-case we use Jurrasic as our FM for building the chatbot."
    ]
@@ -66,11 +66,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
-    "%pip install --force-reinstall \\\n",
+    "%pip install --no-build-isolation --force-reinstall \\\n",
     "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
     "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
     "    ../dependencies/botocore-1.29.162-py3-none-any.whl"
@@ -1218,9 +1220,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science 2.0)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-38"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1232,7 +1234,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/04_Chatbot/00_Chatbot_Claude.ipynb
+++ b/04_Chatbot/00_Chatbot_Claude.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Conversational Interface - Chatbot with Claude LLM\n",
     "\n",
-    "> *This notebook should work well with the **`Data Science 2.0`** kernel in SageMaker Studio*\n",
+    "> *This notebook should work well with the **`Data Science 3.0`** kernel in SageMaker Studio*\n",
     "\n",
     "In this notebook, we will build a chatbot using the Foundational Models (FMs) in Amazon Bedrock. For our use-case we use Claude as our FM for building the chatbot."
    ]
@@ -70,7 +70,7 @@
    "outputs": [],
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
-    "%pip install --force-reinstall \\\n",
+    "%pip install --no-build-isolation --force-reinstall \\\n",
     "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
     "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
     "    ../dependencies/botocore-1.29.162-py3-none-any.whl"
@@ -1359,9 +1359,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science 2.0)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-38"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1373,7 +1373,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/04_Chatbot/00_Chatbot_Titan.ipynb
+++ b/04_Chatbot/00_Chatbot_Titan.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Conversational Interface - Chatbot with Titan LLM\n",
     "\n",
-    "> *This notebook should work well with the **`Data Science 2.0`** kernel in SageMaker Studio*\n",
+    "> *This notebook should work well with the **`Data Science 3.0`** kernel in SageMaker Studio*\n",
     "\n",
     "In this notebook, we will build a chatbot using the Foundational Models (FMs) in Amazon Bedrock. For our use-case we use Titan as our FM for building the chatbot."
    ]
@@ -70,7 +70,7 @@
    "outputs": [],
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
-    "%pip install --force-reinstall \\\n",
+    "%pip install --no-build-isolation --force-reinstall \\\n",
     "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
     "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
     "    ../dependencies/botocore-1.29.162-py3-none-any.whl"
@@ -1212,9 +1212,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science 2.0)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-38"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1226,7 +1226,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/05_Image/Bedrock Stable Diffusion XL.ipynb
+++ b/05_Image/Bedrock Stable Diffusion XL.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Generating images using Stable Diffusion\n",
     "\n",
-    "> *This notebook should work well with the **`Data Science 2.0`** kernel in SageMaker Studio*\n",
+    "> *This notebook should work well with the **`Data Science 3.0`** kernel in SageMaker Studio*\n",
     "\n",
     "---\n",
     "\n",
@@ -66,7 +66,7 @@
    "outputs": [],
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
-    "%pip install --force-reinstall \\\n",
+    "%pip install --no-build-isolation --force-reinstall \\\n",
     "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
     "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
     "    ../dependencies/botocore-1.29.162-py3-none-any.whl\n",
@@ -912,9 +912,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science 2.0)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-38"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -926,7 +926,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
**Issue #, if available:** #7, Fixes #12

**Description of changes:**

- Add `--no-build-isolation` to awscli install commands to work around install error (#7) caused by yaml/pyyaml#601.
- Updated kernel selection guidance, as this change allows the notebooks to work in Studio Data Science 3.0 kernel

**Testing done:**

Tested all notebooks on Studio DataSci 3.0 kernel. @Mohannadcse confirmed in #15 that this fix should also work for at least some of the non-SMStudio environments facing #7.

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
