### PR TITLE
fix: Removed hard coding of dependency versions so that an update to the versions in bedrock-python-sdk.zip does not break the installation instructions

### DIFF
--- a/00_Intro/bedrock_boto3_setup.ipynb
+++ b/00_Intro/bedrock_boto3_setup.ipynb
@@ -39,9 +39,9 @@
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
     "%pip install --no-build-isolation --force-reinstall \\\n",
-    "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
-    "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
-    "    ../dependencies/botocore-1.29.162-py3-none-any.whl"
+    "    ../dependencies/awscli-*-py3-none-any.whl \\\n",
+    "    ../dependencies/boto3-*-py3-none-any.whl \\\n",
+    "    ../dependencies/botocore-*-py3-none-any.whl"
    ]
   },
   {

--- a/01_Generation/00_generate_w_bedrock.ipynb
+++ b/01_Generation/00_generate_w_bedrock.ipynb
@@ -68,9 +68,9 @@
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
     "%pip install --no-build-isolation --force-reinstall \\\n",
-    "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
-    "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
-    "    ../dependencies/botocore-1.29.162-py3-none-any.whl\n",
+    "    ../dependencies/awscli-*-py3-none-any.whl \\\n",
+    "    ../dependencies/boto3-*-py3-none-any.whl \\\n",
+    "    ../dependencies/botocore-*-py3-none-any.whl\n",
     "\n",
     "%pip install --quiet langchain==0.0.249"
    ]

--- a/01_Generation/01_zero_shot_generation.ipynb
+++ b/01_Generation/01_zero_shot_generation.ipynb
@@ -66,9 +66,9 @@
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
     "%pip install --no-build-isolation --force-reinstall \\\n",
-    "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
-    "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
-    "    ../dependencies/botocore-1.29.162-py3-none-any.whl\n",
+    "    ../dependencies/awscli-*-py3-none-any.whl \\\n",
+    "    ../dependencies/boto3-*-py3-none-any.whl \\\n",
+    "    ../dependencies/botocore-*-py3-none-any.whl\n",
     "\n",
     "%pip install --quiet langchain==0.0.249"
    ]

--- a/01_Generation/02_contextual_generation.ipynb
+++ b/01_Generation/02_contextual_generation.ipynb
@@ -74,9 +74,9 @@
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
     "%pip install --no-build-isolation --force-reinstall \\\n",
-    "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
-    "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
-    "    ../dependencies/botocore-1.29.162-py3-none-any.whl\n",
+    "    ../dependencies/awscli-*-py3-none-any.whl \\\n",
+    "    ../dependencies/boto3-*-py3-none-any.whl \\\n",
+    "    ../dependencies/botocore-*-py3-none-any.whl\n",
     "\n",
     "%pip install --quiet langchain==0.0.249 \"transformers>=4.24,<5\""
    ]

--- a/02_Summarization/01.small-text-summarization-claude.ipynb
+++ b/02_Summarization/01.small-text-summarization-claude.ipynb
@@ -61,9 +61,9 @@
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
     "%pip install --no-build-isolation --force-reinstall \\\n",
-    "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
-    "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
-    "    ../dependencies/botocore-1.29.162-py3-none-any.whl\n",
+    "    ../dependencies/awscli-*-py3-none-any.whl \\\n",
+    "    ../dependencies/boto3-*-py3-none-any.whl \\\n",
+    "    ../dependencies/botocore-*-py3-none-any.whl\n",
     "\n",
     "%pip install --quiet langchain==0.0.249"
    ]

--- a/02_Summarization/01.small-text-summarization-titan.ipynb
+++ b/02_Summarization/01.small-text-summarization-titan.ipynb
@@ -60,9 +60,9 @@
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
     "%pip install --no-build-isolation --force-reinstall \\\n",
-    "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
-    "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
-    "    ../dependencies/botocore-1.29.162-py3-none-any.whl\n",
+    "    ../dependencies/awscli-*-py3-none-any.whl \\\n",
+    "    ../dependencies/boto3-*-py3-none-any.whl \\\n",
+    "    ../dependencies/botocore-*-py3-none-any.whl\n",
     "\n",
     "%pip install --quiet langchain==0.0.249"
    ]

--- a/02_Summarization/02.long-text-summarization-titan.ipynb
+++ b/02_Summarization/02.long-text-summarization-titan.ipynb
@@ -61,9 +61,9 @@
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
     "%pip install --no-build-isolation --force-reinstall \\\n",
-    "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
-    "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
-    "    ../dependencies/botocore-1.29.162-py3-none-any.whl\n",
+    "    ../dependencies/awscli-*-py3-none-any.whl \\\n",
+    "    ../dependencies/boto3-*-py3-none-any.whl \\\n",
+    "    ../dependencies/botocore-*-py3-none-any.whl\n",
     "\n",
     "%pip install --quiet langchain==0.0.249 \"transformers>=4.24,<5\""
    ]

--- a/03_QuestionAnswering/00_qa_w_bedrock_titan.ipynb
+++ b/03_QuestionAnswering/00_qa_w_bedrock_titan.ipynb
@@ -45,9 +45,9 @@
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
     "%pip install --no-build-isolation --force-reinstall \\\n",
-    "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
-    "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
-    "    ../dependencies/botocore-1.29.162-py3-none-any.whl\n",
+    "    ../dependencies/awscli-*-py3-none-any.whl \\\n",
+    "    ../dependencies/boto3-*-py3-none-any.whl \\\n",
+    "    ../dependencies/botocore-*-py3-none-any.whl\n",
     "\n",
     "%pip install --quiet langchain==0.0.249"
    ]

--- a/03_QuestionAnswering/01_qa_w_rag_claude.ipynb
+++ b/03_QuestionAnswering/01_qa_w_rag_claude.ipynb
@@ -114,9 +114,9 @@
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
     "%pip install --no-build-isolation --force-reinstall \\\n",
-    "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
-    "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
-    "    ../dependencies/botocore-1.29.162-py3-none-any.whl\n",
+    "    ../dependencies/awscli-*-py3-none-any.whl \\\n",
+    "    ../dependencies/boto3-*-py3-none-any.whl \\\n",
+    "    ../dependencies/botocore-*-py3-none-any.whl\n",
     "\n",
     "%pip install --quiet \"faiss-cpu>=1.7,<2\" langchain==0.0.249 \"pypdf>=3.8,<4\""
    ]

--- a/04_Chatbot/00_Chatbot_AI21.ipynb
+++ b/04_Chatbot/00_Chatbot_AI21.ipynb
@@ -73,9 +73,9 @@
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
     "%pip install --no-build-isolation --force-reinstall \\\n",
-    "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
-    "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
-    "    ../dependencies/botocore-1.29.162-py3-none-any.whl"
+    "    ../dependencies/awscli-*-py3-none-any.whl \\\n",
+    "    ../dependencies/boto3-*-py3-none-any.whl \\\n",
+    "    ../dependencies/botocore-*-py3-none-any.whl"
    ]
   },
   {

--- a/04_Chatbot/00_Chatbot_Claude.ipynb
+++ b/04_Chatbot/00_Chatbot_Claude.ipynb
@@ -71,9 +71,9 @@
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
     "%pip install --no-build-isolation --force-reinstall \\\n",
-    "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
-    "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
-    "    ../dependencies/botocore-1.29.162-py3-none-any.whl"
+    "    ../dependencies/awscli-*-py3-none-any.whl \\\n",
+    "    ../dependencies/boto3-*-py3-none-any.whl \\\n",
+    "    ../dependencies/botocore-*-py3-none-any.whl"
    ]
   },
   {

--- a/04_Chatbot/00_Chatbot_Titan.ipynb
+++ b/04_Chatbot/00_Chatbot_Titan.ipynb
@@ -71,9 +71,9 @@
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
     "%pip install --no-build-isolation --force-reinstall \\\n",
-    "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
-    "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
-    "    ../dependencies/botocore-1.29.162-py3-none-any.whl"
+    "    ../dependencies/awscli-*-py3-none-any.whl \\\n",
+    "    ../dependencies/boto3-*-py3-none-any.whl \\\n",
+    "    ../dependencies/botocore-*-py3-none-any.whl"
    ]
   },
   {

--- a/05_Image/Bedrock Stable Diffusion XL.ipynb
+++ b/05_Image/Bedrock Stable Diffusion XL.ipynb
@@ -67,9 +67,9 @@
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
     "%pip install --no-build-isolation --force-reinstall \\\n",
-    "    ../dependencies/awscli-1.27.162-py3-none-any.whl \\\n",
-    "    ../dependencies/boto3-1.26.162-py3-none-any.whl \\\n",
-    "    ../dependencies/botocore-1.29.162-py3-none-any.whl\n",
+    "    ../dependencies/awscli-*-py3-none-any.whl \\\n",
+    "    ../dependencies/boto3-*-py3-none-any.whl \\\n",
+    "    ../dependencies/botocore-*-py3-none-any.whl\n",
     "\n",
     "%pip install --quiet \"pillow>=9.5,<10\""
    ]

--- a/download-dependencies.sh
+++ b/download-dependencies.sh
@@ -6,7 +6,7 @@ cd ./dependencies
 # Removing prior dependencies
 rm -rf * 
 echo "Downloading dependencies"
-curl -sS https://preview.documentation.bedrock.aws.dev/Documentation/SDK/bedrock-python-sdk.zip > sdk.zip && \
+curl -sS https://d2eo22ngex1n9g.cloudfront.net/Documentation/SDK/bedrock-python-sdk.zip > sdk.zip && \
 echo "Unpacking dependencies"
 # (SageMaker Studio system terminals don't have `unzip` utility installed)
 if command -v unzip &> /dev/null

--- a/download-dependencies.sh
+++ b/download-dependencies.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
 
-echo "Creating directory"
-mkdir -p ./dependencies && \
+set -e
+
+echo "(Re)-creating directory"
+rm -rf ./dependencies
+mkdir ./dependencies
 cd ./dependencies
-# Removing prior dependencies
-rm -rf * 
 echo "Downloading dependencies"
-curl -sS https://d2eo22ngex1n9g.cloudfront.net/Documentation/SDK/bedrock-python-sdk.zip > sdk.zip && \
+curl -sS https://d2eo22ngex1n9g.cloudfront.net/Documentation/SDK/bedrock-python-sdk.zip > sdk.zip
 echo "Unpacking dependencies"
 # (SageMaker Studio system terminals don't have `unzip` utility installed)
 if command -v unzip &> /dev/null

--- a/download-dependencies.sh
+++ b/download-dependencies.sh
@@ -2,7 +2,9 @@
 
 echo "Creating directory"
 mkdir -p ./dependencies && \
-cd ./dependencies && \
+cd ./dependencies
+# Removing prior dependencies
+rm -rf * 
 echo "Downloading dependencies"
 curl -sS https://preview.documentation.bedrock.aws.dev/Documentation/SDK/bedrock-python-sdk.zip > sdk.zip && \
 echo "Unpacking dependencies"


### PR DESCRIPTION
*Issue #, if available:* 22

*Description of changes:* 
* When running download-dependencies.sh, the contents of the dependencies directory is deleted to remove any prior versions of dependencies
* The instructions for installing the prerequisites (awscli, boto3, botocore) have been changed to use a wildcard rather than a hard coded version number.  This is so that when the dependency versions are updated in bedrock-python-sdk.zip, the installation instructions still work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
