### PR TITLE
Use foundation instead of foundational

### DIFF
--- a/00_Intro/bedrock_boto3_setup.ipynb
+++ b/00_Intro/bedrock_boto3_setup.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "---\n",
     "\n",
-    "In this demo notebook, we demonstrate how to use the [`boto3` Python SDK](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) to work with [Amazon Bedrock](https://aws.amazon.com/bedrock/) Foundational Models.\n",
+    "In this demo notebook, we demonstrate how to use the [`boto3` Python SDK](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) to work with [Amazon Bedrock](https://aws.amazon.com/bedrock/) Foundation Models.\n",
     "\n",
     "---"
    ]

--- a/02_Summarization/01.small-text-summarization-claude.ipynb
+++ b/02_Summarization/01.small-text-summarization-claude.ipynb
@@ -26,7 +26,7 @@
     "In this architecture:\n",
     "\n",
     "1. A small piece of text (or small file) is loaded\n",
-    "1. A foundational model processes the input data\n",
+    "1. A foundation model processes the input data\n",
     "1. Model returns a response with the summary of the ingested text\n",
     "\n",
     "### Use case\n",

--- a/02_Summarization/01.small-text-summarization-titan.ipynb
+++ b/02_Summarization/01.small-text-summarization-titan.ipynb
@@ -26,7 +26,7 @@
     "In this architecture:\n",
     "\n",
     "1. A small piece of text (or small file) is loaded\n",
-    "1. A foundational model processes those data\n",
+    "1. A foundation model processes those data\n",
     "1. Model returns a response with the summary of the ingested text\n",
     "\n",
     "### Use case\n",

--- a/03_QuestionAnswering/00_qa_w_bedrock_titan.ipynb
+++ b/03_QuestionAnswering/00_qa_w_bedrock_titan.ipynb
@@ -96,7 +96,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this Notebook we will be using the `invoke_model()` method of Amazon Bedrock client. The mandatory parameters required to use this method are `modelId` which represents the Amazon Bedrock model ARN, and `body` which is the prompt for our task. The `body` prompt changes depending on the foundational model provider selected. We walk through this in detail below\n",
+    "In this Notebook we will be using the `invoke_model()` method of Amazon Bedrock client. The mandatory parameters required to use this method are `modelId` which represents the Amazon Bedrock model ARN, and `body` which is the prompt for our task. The `body` prompt changes depending on the foundation model provider selected. We walk through this in detail below\n",
     "\n",
     "```\n",
     "{\n",

--- a/04_Chatbot/00_Chatbot_AI21.ipynb
+++ b/04_Chatbot/00_Chatbot_AI21.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "> *This notebook should work well with the **`Data Science 3.0`** kernel in SageMaker Studio*\n",
     "\n",
-    "In this notebook, we will build a chatbot using the Foundational Models (FMs) in Amazon Bedrock. For our use-case we use Jurrasic as our FM for building the chatbot."
+    "In this notebook, we will build a chatbot using the Foundation Models (FMs) in Amazon Bedrock. For our use-case we use Jurrasic as our FM for building the chatbot."
    ]
   },
   {

--- a/04_Chatbot/00_Chatbot_Claude.ipynb
+++ b/04_Chatbot/00_Chatbot_Claude.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "> *This notebook should work well with the **`Data Science 3.0`** kernel in SageMaker Studio*\n",
     "\n",
-    "In this notebook, we will build a chatbot using the Foundational Models (FMs) in Amazon Bedrock. For our use-case we use Claude as our FM for building the chatbot."
+    "In this notebook, we will build a chatbot using the Foundation Models (FMs) in Amazon Bedrock. For our use-case we use Claude as our FM for building the chatbot."
    ]
   },
   {

--- a/04_Chatbot/00_Chatbot_Titan.ipynb
+++ b/04_Chatbot/00_Chatbot_Titan.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "> *This notebook should work well with the **`Data Science 3.0`** kernel in SageMaker Studio*\n",
     "\n",
-    "In this notebook, we will build a chatbot using the Foundational Models (FMs) in Amazon Bedrock. For our use-case we use Titan as our FM for building the chatbot."
+    "In this notebook, we will build a chatbot using the Foundation Models (FMs) in Amazon Bedrock. For our use-case we use Titan as our FM for building the chatbot."
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

1. Update occurrences of `foundational` => `foundation`. In other words use Foundation Model, not Foundational Model.
2. The "About" settings of the project currently shows `This is a workshop designed for Amazon Bedrock a **foundational** model service.` so that needs a fix as well (probably with a comma), something like `This is a workshop designed for Amazon Bedrock, a foundation model service.`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
