### PR TITLE
with a new user in SageMaker Studio, the unzip must be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ For more information on the fine-grained action and resource permissions in Bedr
 Once your notebook environment is set up, clone this workshop repository into it.
 
 ```sh
+sudo yum install -y unzip
 git clone https://github.com/aws-samples/amazon-bedrock-workshop.git
 cd amazon-bedrock-workshop
 ```


### PR DESCRIPTION
After cloning the repo in SageMaker studio, us-west-2 in the terminal, when doing "bash ./download_dependencies.sh" it will fail to unzip with the error:
"'unzip' command not found: Trying to unzip via Python"