### PR TITLE
Added better prompt template and role aliases for Titan.

### DIFF
--- a/04_Chatbot/00_Chatbot_Titan.ipynb
+++ b/04_Chatbot/00_Chatbot_Titan.ipynb
@@ -154,10 +154,16 @@
     "from langchain.memory import ConversationBufferMemory\n",
     "\n",
     "titan_llm = Bedrock(model_id=\"amazon.titan-tg1-large\", client=boto3_bedrock)\n",
+    "titan_llm.model_kwargs = {'temperature': 0.5, \"maxTokenCount\": 700}\n",
+    "\n",
     "memory = ConversationBufferMemory()\n",
+    "memory.human_prefix = \"User\"\n",
+    "memory.ai_prefix = \"Bot\"\n",
+    "\n",
     "conversation = ConversationChain(\n",
     "    llm=titan_llm, verbose=True, memory=memory\n",
     ")\n",
+    "conversation.prompt.template = \"\"\"System: The following is a friendly conversation between a knowledgeable helpful assistant and a customer. The assistant is talkative and provides lots of specific details from it's context.\\n\\nCurrent conversation:\\n{history}\\nUser: {input}\\nBot:\"\"\"\n",
     "\n",
     "print_ww(conversation.predict(input=\"Hi there!\"))"
    ]
@@ -247,10 +253,15 @@
     "\n",
     "chat_history = []\n",
     "\n",
+    "memory=ConversationBufferMemory()\n",
+    "memory.human_prefix = \"User\"\n",
+    "memory.ai_prefix = \"Bot\"\n",
+    "\n",
     "# turn verbose to true to see the full logs and documents\n",
     "qa= ConversationChain(\n",
-    "    llm=titan_llm, verbose=False, memory=ConversationBufferMemory() #memory_chain\n",
+    "    llm=titan_llm, verbose=False, memory=memory #memory_chain\n",
     ")\n",
+    "qa.prompt.template = \"\"\"System: The following is a friendly conversation between a knowledgeable helpful assistant and a customer. The assistant is talkative and provides lots of specific details from it's context.\\n\\nCurrent conversation:\\n{history}\\nUser: {input}\\nBot:\"\"\"\n",
     "\n",
     "print(f\"ChatBot:DEFAULT:PROMPT:TEMPLATE: is ={qa.prompt.template}\")"
    ]
@@ -1212,9 +1223,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science 3.0)",
+   "display_name": "conda_python3",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
+   "name": "conda_python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1226,7 +1237,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Modified first few cells demonstrating Titan as a conversational agent. Made some general improvements,

- Tweaked inference configuration to Titan for longer generation.

- Set and changed the prompt template. I'm aware that subsequent cells demonstrate the prompt template functionality, and this might detract from that. However, Titan presents significant instability when not assuming certain prefixes in a chat dialog. Being, specifically the User and Bot aliases. The default langchain conversational template also is primarily aligned to perform well with instruction tuned models.

- + tweaked the prefixes in the memory buffer to align with the above point.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
