### PR TITLE
claude-instant-v1

### DIFF
--- a/01_Generation/00_generate_w_bedrock.ipynb
+++ b/01_Generation/00_generate_w_bedrock.ipynb
@@ -181,7 +181,7 @@
     "- `amazon.titan-tg1-large`\n",
     "- `ai21.j2-grande-instruct`\n",
     "- `ai21.j2-jumbo-instruct`\n",
-    "- `anthropic.claude-instant-v2`\n",
+    "- `anthropic.claude-instant-v1`\n",
     "- `anthropic.claude-v2`"
    ]
   },

--- a/01_Generation/01_zero_shot_generation.ipynb
+++ b/01_Generation/01_zero_shot_generation.ipynb
@@ -126,7 +126,7 @@
     "- amazon.titan-tg1-large\n",
     "- ai21.j2-grande-instruct\n",
     "- ai21.j2-jumbo-instruct\n",
-    "- anthropic.claude-instant-v2\n",
+    "- anthropic.claude-instant-v1\n",
     "- anthropic.claude-v2\n",
     "\n",
     "Note that different models support different `model_kwargs`."

--- a/01_Generation/02_contextual_generation.ipynb
+++ b/01_Generation/02_contextual_generation.ipynb
@@ -134,7 +134,7 @@
     "- amazon.titan-tg1-large\n",
     "- ai21.j2-grande-instruct\n",
     "- ai21.j2-jumbo-instruct\n",
-    "- anthropic.claude-instant-v2\n",
+    "- anthropic.claude-instant-v1\n",
     "- anthropic.claude-v2\n",
     "\n",
     "Note that different models support different `model_kwargs`."

--- a/06_CodeGeneration/02_code_interpret_w_langchain.ipynb
+++ b/06_CodeGeneration/02_code_interpret_w_langchain.ipynb
@@ -130,7 +130,7 @@
     "- amazon.titan-tg1-large\n",
     "- ai21.j2-grande-instruct\n",
     "- ai21.j2-jumbo-instruct\n",
-    "- anthropic.claude-instant-v2\n",
+    "- anthropic.claude-instant-v1\n",
     "- anthropic.claude-v2\n",
     "\n",
     "Note that different models support different `model_kwargs`."

--- a/06_CodeGeneration/03_code_translate_w_langchain.ipynb
+++ b/06_CodeGeneration/03_code_translate_w_langchain.ipynb
@@ -129,7 +129,7 @@
     "- amazon.titan-tg1-large\n",
     "- ai21.j2-grande-instruct\n",
     "- ai21.j2-jumbo-instruct\n",
-    "- anthropic.claude-instant-v2\n",
+    "- anthropic.claude-instant-v1\n",
     "- anthropic.claude-v2\n",
     "\n",
     "Note that different models support different `model_kwargs`."


### PR DESCRIPTION
move instant version to v1 (which syncs to latest big-number version, in this case 1.2)