### PR TITLE
Change outputText to completion in stream mode.

### DIFF
--- a/00_Intro/bedrock_boto3_setup.ipynb
+++ b/00_Intro/bedrock_boto3_setup.ipynb
@@ -662,7 +662,7 @@
     "        chunk = event.get('chunk')\n",
     "        if chunk:\n",
     "            chunk_obj = json.loads(chunk.get('bytes').decode())\n",
-    "            text = chunk_obj['outputText']\n",
+    "            text = chunk_obj['completion']\n",
     "            clear_output(wait=True)\n",
     "            output.append(text)\n",
     "            display_markdown(Markdown(''.join(output)))"


### PR DESCRIPTION
Currently the respective cell is throwing a KeyError with outputText. In stream mode, using claude-v2, each line starts with the keyword completion and not outputText.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
