### PR TITLE
PromptTable has moved under langchain.prompts

### DIFF
--- a/01_Generation/02_contextual_generation.ipynb
+++ b/01_Generation/02_contextual_generation.ipynb
@@ -186,7 +186,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain import PromptTemplate\n",
+    "from langchain.prompts import PromptTemplate\n",
     "\n",
     "# Create a prompt template that has multiple input variables\n",
     "multi_var_prompt = PromptTemplate(\n",

--- a/04_Chatbot/00_Chatbot_AI21.ipynb
+++ b/04_Chatbot/00_Chatbot_AI21.ipynb
@@ -258,7 +258,7 @@
    "outputs": [],
    "source": [
     "from langchain.memory import ConversationBufferMemory\n",
-    "from langchain import PromptTemplate\n",
+    "from langchain.prompts import PromptTemplate\n",
     "\n",
     "chat_history = []\n",
     "\n",

--- a/04_Chatbot/00_Chatbot_Claude.ipynb
+++ b/04_Chatbot/00_Chatbot_Claude.ipynb
@@ -205,7 +205,7 @@
    "outputs": [],
    "source": [
     "from langchain.memory import ConversationBufferMemory\n",
-    "from langchain import PromptTemplate\n",
+    "from langchain.prompts import PromptTemplate\n",
     "\n",
     "# turn verbose to true to see the full logs and documents\n",
     "conversation= ConversationChain(\n",

--- a/04_Chatbot/00_Chatbot_Titan.ipynb
+++ b/04_Chatbot/00_Chatbot_Titan.ipynb
@@ -255,7 +255,7 @@
    "outputs": [],
    "source": [
     "from langchain.memory import ConversationBufferMemory\n",
-    "from langchain import PromptTemplate\n",
+    "from langchain.prompts import PromptTemplate\n",
     "\n",
     "chat_history = []\n",
     "\n",

--- a/06_CodeGeneration/02_code_interpret_w_langchain.ipynb
+++ b/06_CodeGeneration/02_code_interpret_w_langchain.ipynb
@@ -274,7 +274,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain import PromptTemplate\n",
+    "from langchain.prompts import PromptTemplate\n",
     "\n",
     "# Create a prompt template that has multiple input variables\n",
     "multi_var_prompt = PromptTemplate(\n",

--- a/06_CodeGeneration/03_code_translate_w_langchain.ipynb
+++ b/06_CodeGeneration/03_code_translate_w_langchain.ipynb
@@ -271,7 +271,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain import PromptTemplate\n",
+    "from langchain.prompts import PromptTemplate\n",
     "\n",
     "# Create a prompt template that has multiple input variables\n",
     "multi_var_prompt = PromptTemplate(\n",


### PR DESCRIPTION
To fix the error below

`/opt/conda/lib/python3.10/site-packages/langchain/__init__.py:24: UserWarning: Importing PromptTemplate from langchain root module is no longer supported.
  warnings.warn(
`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
