### PR TITLE
add Anthropic Claude streaming example

### DIFF
--- a/00_Intro/bedrock_boto3_setup.ipynb
+++ b/00_Intro/bedrock_boto3_setup.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "88a5ab2f-d044-4956-b75b-7408d9c3e323",
    "metadata": {},
@@ -18,7 +17,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "6aeedd9f-f0a3-4f8e-934d-22f6f7a89de5",
    "metadata": {},
@@ -46,7 +44,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "3f1c8940",
    "metadata": {},
@@ -67,7 +64,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "27610c0f-7de6-4440-8f76-decf30e3c5ca",
    "metadata": {},
@@ -139,7 +135,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "9e9174c4-326a-463e-92e1-8c7e47111269",
    "metadata": {},
@@ -162,7 +157,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "2f690043-df45-448f-8fa6-1ea8b06f1087",
    "metadata": {
@@ -179,7 +173,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "a4650fa3-a831-4039-9fd6-749926d35979",
    "metadata": {},
@@ -213,7 +206,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "6ca0c329-ff58-483e-8abd-63867950c14b",
    "metadata": {},
@@ -280,7 +272,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "7adb6bee-7654-4269-9127-9afa4e823454",
    "metadata": {},
@@ -311,7 +302,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "fb94aa2f-30da-499b-b3f5-02f102dbb1ea",
    "metadata": {},
@@ -349,7 +339,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "80f4adca-cfc4-439b-84b7-e528398684e3",
    "metadata": {
@@ -418,7 +407,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "ce22c308-ebbf-4ef5-a823-832b7c236e31",
    "metadata": {},
@@ -444,7 +432,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "893872fe-04fa-4f09-9736-6c6173ec1fc2",
    "metadata": {
@@ -493,7 +480,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "3d7c0fe6-576a-4380-89aa-726bab5d65ff",
    "metadata": {},
@@ -540,7 +526,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "ed0e3144-c6df-400d-aab1-1540614dbbde",
    "metadata": {},
@@ -571,7 +556,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "bc498bea",
    "metadata": {},
@@ -607,7 +591,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "1a271fa6-13fd-480a-87a5-3702d29a5c43",
    "metadata": {},
@@ -625,7 +608,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "4621a301-53e4-4182-9fce-8ee422813e9d",
    "metadata": {},
@@ -635,6 +617,14 @@
     "For large language models, it can take noticeable time to generate long output sequences. Rather than waiting for the entire response to be available, latency-sensitive applications may like to **stream** the response to users.\n",
     "\n",
     "Run the code below to see how you can achieve this with Bedrock's `invoke_model_with_response_stream()` method - returning the response body in separate chunks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e8cf7cb-fd81-4412-ab7e-6576a435ab97",
+   "metadata": {},
+   "source": [
+    "### Amazon Titan Large"
    ]
   },
   {
@@ -669,7 +659,48 @@
    ]
   },
   {
-   "attachments": {},
+   "cell_type": "markdown",
+   "id": "a54c3412-e1f2-4d85-9d6b-dcf8054c207c",
+   "metadata": {},
+   "source": [
+    "### Anthropic Claude"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdfa701c-53c4-4fc9-a203-0044197f091d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from IPython.display import clear_output, display, display_markdown, Markdown\n",
+    "\n",
+    "body = json.dumps({\"prompt\": prompt_data, \"max_tokens_to_sample\": 500})\n",
+    "modelId = \"anthropic.claude-instant-v1\"  # (Change this, to try different claude model versions)\n",
+    "accept = \"application/json\"\n",
+    "contentType = \"application/json\"\n",
+    "\n",
+    "response = bedrock_runtime.invoke_model_with_response_stream(\n",
+    "    body=body, modelId=modelId, accept=accept, contentType=contentType\n",
+    ")\n",
+    "stream = response.get('body')\n",
+    "output = []\n",
+    "\n",
+    "if stream:\n",
+    "    for event in stream:\n",
+    "        chunk = event.get('chunk')\n",
+    "        if chunk:\n",
+    "            chunk_obj = json.loads(chunk.get('bytes').decode())\n",
+    "            print(chunk_obj)\n",
+    "            text = chunk_obj['completion']\n",
+    "            clear_output(wait=True)\n",
+    "            output.append(text)\n",
+    "            display_markdown(Markdown(''.join(output)))"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "1ef3451d-b66a-4b11-a1ed-734bf9e7bbec",
    "metadata": {},
@@ -706,7 +737,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "9645dbd8",
    "metadata": {},
@@ -748,7 +778,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "5a48a0e8-147d-4525-a6b2-68a09af1b2c4",
    "metadata": {},
@@ -1351,10 +1380,11 @@
     "vcpuNum": 96
    }
   ],
+  "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1366,7 +1396,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
An example of generating streaming output for Anthropic Claude is added to the next cell of the TITAN example cell.
The following three points are different from TITAN.
- body
- modelId
- JSON key of chunk_obj (TITAN: outputText -> Claude: completion)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
