### PR TITLE
added error handling for Bedrock Titan models

### DIFF
--- a/00_Intro/bedrock_boto3_setup.ipynb
+++ b/00_Intro/bedrock_boto3_setup.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "88a5ab2f-d044-4956-b75b-7408d9c3e323",
    "metadata": {},
@@ -18,7 +17,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "6aeedd9f-f0a3-4f8e-934d-22f6f7a89de5",
    "metadata": {},
@@ -46,7 +44,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "3f1c8940",
    "metadata": {},
@@ -63,11 +60,10 @@
    },
    "outputs": [],
    "source": [
-    "%pip install --quiet langchain==0.0.304"
+    "%pip install --quiet langchain==0.0.309"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "27610c0f-7de6-4440-8f76-decf30e3c5ca",
    "metadata": {},
@@ -110,7 +106,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ae2b2a05-78a9-40ca-9b5e-121030f9ede1",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import json\n",
@@ -118,6 +116,7 @@
     "import sys\n",
     "\n",
     "import boto3\n",
+    "import botocore\n",
     "\n",
     "module_path = \"..\"\n",
     "sys.path.append(os.path.abspath(module_path))\n",
@@ -139,7 +138,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "9e9174c4-326a-463e-92e1-8c7e47111269",
    "metadata": {},
@@ -162,7 +160,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "2f690043-df45-448f-8fa6-1ea8b06f1087",
    "metadata": {
@@ -179,7 +176,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "a4650fa3-a831-4039-9fd6-749926d35979",
    "metadata": {},
@@ -213,7 +209,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "6ca0c329-ff58-483e-8abd-63867950c14b",
    "metadata": {},
@@ -280,7 +275,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "7adb6bee-7654-4269-9127-9afa4e823454",
    "metadata": {},
@@ -311,7 +305,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "fb94aa2f-30da-499b-b3f5-02f102dbb1ea",
    "metadata": {},
@@ -349,7 +342,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "80f4adca-cfc4-439b-84b7-e528398684e3",
    "metadata": {
@@ -418,7 +410,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "ce22c308-ebbf-4ef5-a823-832b7c236e31",
    "metadata": {},
@@ -434,7 +425,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6a0a79b9",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "bedrock_runtime = bedrock.get_bedrock_client(\n",
@@ -444,7 +437,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "893872fe-04fa-4f09-9736-6c6173ec1fc2",
    "metadata": {
@@ -479,21 +471,30 @@
    },
    "outputs": [],
    "source": [
-    "body = json.dumps({\"inputText\": prompt_data})\n",
-    "modelId = \"amazon.titan-tg1-large\"\n",
-    "accept = \"application/json\"\n",
-    "contentType = \"application/json\"\n",
+    "try:\n",
+    "    \n",
+    "    body = json.dumps({\"inputText\": prompt_data})\n",
+    "    modelId = \"amazon.titan-tg1-large\"\n",
+    "    accept = \"application/json\"\n",
+    "    contentType = \"application/json\"\n",
     "\n",
-    "response = bedrock_runtime.invoke_model(\n",
-    "    body=body, modelId=modelId, accept=accept, contentType=contentType\n",
-    ")\n",
-    "response_body = json.loads(response.get(\"body\").read())\n",
+    "    response = bedrock_runtime.invoke_model(\n",
+    "        body=body, modelId=modelId, accept=accept, contentType=contentType\n",
+    "    )\n",
+    "    response_body = json.loads(response.get(\"body\").read())\n",
     "\n",
-    "print(response_body.get(\"results\")[0].get(\"outputText\"))"
+    "    print(response_body.get(\"results\")[0].get(\"outputText\"))\n",
+    "\n",
+    "except botocore.exceptions.ClientError as error:\n",
+    "    \n",
+    "    if error.response['Error']['Code'] == 'AccessDeniedException' and \"Your account is not authorized to invoke this API operation\" in error.response['Error']['Message']:\n",
+    "        print(f\"\\t\\t\\x1b[41mYour account doesn't have access to '{modelId}' model.\\x1b[0m\\n\")\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "3d7c0fe6-576a-4380-89aa-726bab5d65ff",
    "metadata": {},
@@ -531,16 +532,25 @@
     "accept = \"application/json\"\n",
     "contentType = \"application/json\"\n",
     "\n",
-    "response = bedrock_runtime.invoke_model(\n",
-    "    body=body, modelId=modelId, accept=accept, contentType=contentType\n",
-    ")\n",
-    "response_body = json.loads(response.get(\"body\").read())\n",
+    "try:\n",
+    "    \n",
+    "    response = bedrock_runtime.invoke_model(\n",
+    "        body=body, modelId=modelId, accept=accept, contentType=contentType\n",
+    "    )\n",
+    "    response_body = json.loads(response.get(\"body\").read())\n",
     "\n",
-    "print(response_body.get(\"completion\"))"
+    "    print(response_body.get(\"completion\"))\n",
+    "\n",
+    "except botocore.exceptions.ClientError as error:\n",
+    "    \n",
+    "    if error.response['Error']['Code'] == 'AccessDeniedException' and \"Your account is not authorized to invoke this API operation\" in error.response['Error']['Message']:\n",
+    "        print(f\"\\t\\t\\x1b[41mYour account doesn't have access to '{modelId}' model.\\x1b[0m\\n\")\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "ed0e3144-c6df-400d-aab1-1540614dbbde",
    "metadata": {},
@@ -562,16 +572,25 @@
     "accept = \"application/json\"\n",
     "contentType = \"application/json\"\n",
     "\n",
-    "response = bedrock_runtime.invoke_model(\n",
-    "    body=body, modelId=modelId, accept=accept, contentType=contentType\n",
-    ")\n",
-    "response_body = json.loads(response.get(\"body\").read())\n",
+    "try:\n",
+    "    \n",
+    "    response = bedrock_runtime.invoke_model(\n",
+    "        body=body, modelId=modelId, accept=accept, contentType=contentType\n",
+    "    )\n",
+    "    response_body = json.loads(response.get(\"body\").read())\n",
     "\n",
-    "print(response_body.get(\"completions\")[0].get(\"data\").get(\"text\"))"
+    "    print(response_body.get(\"completions\")[0].get(\"data\").get(\"text\"))\n",
+    "\n",
+    "except botocore.exceptions.ClientError as error:\n",
+    "    \n",
+    "    if error.response['Error']['Code'] == 'AccessDeniedException' and \"Your account is not authorized to invoke this API operation\" in error.response['Error']['Message']:\n",
+    "        print(f\"\\t\\t\\x1b[41mYour account doesn't have access to '{modelId}' model.\\x1b[0m\\n\")\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "bc498bea",
    "metadata": {},
@@ -583,7 +602,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "173e51a2",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "prompt_data = \"a fine image of an astronaut riding a horse on Mars\"\n",
@@ -597,17 +618,26 @@
     "accept = \"application/json\"\n",
     "contentType = \"application/json\"\n",
     "\n",
-    "response = bedrock_runtime.invoke_model(\n",
-    "    body=body, modelId=modelId, accept=accept, contentType=contentType\n",
-    ")\n",
-    "response_body = json.loads(response.get(\"body\").read())\n",
+    "try:\n",
+    "    \n",
+    "    response = bedrock_runtime.invoke_model(\n",
+    "        body=body, modelId=modelId, accept=accept, contentType=contentType\n",
+    "    )\n",
+    "    response_body = json.loads(response.get(\"body\").read())\n",
     "\n",
-    "print(response_body[\"result\"])\n",
-    "print(f'{response_body.get(\"artifacts\")[0].get(\"base64\")[0:80]}...')"
+    "    print(response_body[\"result\"])\n",
+    "    print(f'{response_body.get(\"artifacts\")[0].get(\"base64\")[0:80]}...')\n",
+    "\n",
+    "except botocore.exceptions.ClientError as error:\n",
+    "    \n",
+    "    if error.response['Error']['Code'] == 'AccessDeniedException' and \"Your account is not authorized to invoke this API operation\" in error.response['Error']['Message']:\n",
+    "        print(f\"\\t\\t\\x1b[41mYour account doesn't have access to '{modelId}' model.\\x1b[0m\\n\")\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "1a271fa6-13fd-480a-87a5-3702d29a5c43",
    "metadata": {},
@@ -625,7 +655,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "4621a301-53e4-4182-9fce-8ee422813e9d",
    "metadata": {},
@@ -641,7 +670,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c69627e3",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from IPython.display import clear_output, display, display_markdown, Markdown\n",
@@ -651,25 +682,34 @@
     "accept = \"application/json\"\n",
     "contentType = \"application/json\"\n",
     "\n",
-    "response = bedrock_runtime.invoke_model_with_response_stream(\n",
-    "    body=body, modelId=modelId, accept=accept, contentType=contentType\n",
-    ")\n",
-    "stream = response.get('body')\n",
-    "output = []\n",
+    "try:\n",
+    "    \n",
+    "    response = bedrock_runtime.invoke_model_with_response_stream(\n",
+    "        body=body, modelId=modelId, accept=accept, contentType=contentType\n",
+    "    )\n",
+    "    stream = response.get('body')\n",
+    "    output = []\n",
     "\n",
-    "if stream:\n",
-    "    for event in stream:\n",
-    "        chunk = event.get('chunk')\n",
-    "        if chunk:\n",
-    "            chunk_obj = json.loads(chunk.get('bytes').decode())\n",
-    "            text = chunk_obj['outputText']\n",
-    "            clear_output(wait=True)\n",
-    "            output.append(text)\n",
-    "            display_markdown(Markdown(''.join(output)))"
+    "    if stream:\n",
+    "        for event in stream:\n",
+    "            chunk = event.get('chunk')\n",
+    "            if chunk:\n",
+    "                chunk_obj = json.loads(chunk.get('bytes').decode())\n",
+    "                text = chunk_obj['outputText']\n",
+    "                clear_output(wait=True)\n",
+    "                output.append(text)\n",
+    "                display_markdown(Markdown(''.join(output)))\n",
+    "            \n",
+    "except botocore.exceptions.ClientError as error:\n",
+    "    \n",
+    "    if error.response['Error']['Code'] == 'AccessDeniedException' and \"Your account is not authorized to invoke this API operation\" in error.response['Error']['Message']:\n",
+    "        print(f\"\\t\\t\\x1b[41m**Your account doesn't have access to '{modelId}' model.**\\x1b[0m\\n\")\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "1ef3451d-b66a-4b11-a1ed-734bf9e7bbec",
    "metadata": {},
@@ -706,7 +746,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "9645dbd8",
    "metadata": {},
@@ -730,7 +769,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5c54b424",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "body = json.dumps({\"inputText\": prompt_data})\n",
@@ -738,17 +779,26 @@
     "accept = \"application/json\"\n",
     "contentType = \"application/json\"\n",
     "\n",
-    "response = bedrock_runtime.invoke_model(\n",
-    "    body=body, modelId=modelId, accept=accept, contentType=contentType\n",
-    ")\n",
-    "response_body = json.loads(response.get(\"body\").read())\n",
+    "try:\n",
+    "    \n",
+    "    response = bedrock_runtime.invoke_model(\n",
+    "        body=body, modelId=modelId, accept=accept, contentType=contentType\n",
+    "    )\n",
+    "    response_body = json.loads(response.get(\"body\").read())\n",
     "\n",
-    "embedding = response_body.get(\"embedding\")\n",
-    "print(f\"The embedding vector has {len(embedding)} values\\n{embedding[0:3]+['...']+embedding[-3:]}\")"
+    "    embedding = response_body.get(\"embedding\")\n",
+    "    print(f\"The embedding vector has {len(embedding)} values\\n{embedding[0:3]+['...']+embedding[-3:]}\")\n",
+    "\n",
+    "except botocore.exceptions.ClientError as error:\n",
+    "    \n",
+    "    if error.response['Error']['Code'] == 'AccessDeniedException' and \"Your account is not authorized to invoke this API operation\" in error.response['Error']['Message']:\n",
+    "        print(f\"\\t\\t\\x1b[41m**Your account doesn't have access to '{modelId}' model.**\\x1b[0m\\n\")\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "5a48a0e8-147d-4525-a6b2-68a09af1b2c4",
    "metadata": {},
@@ -1351,10 +1401,11 @@
     "vcpuNum": 96
    }
   ],
+  "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1366,7 +1417,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/01_Generation/00_generate_w_bedrock.ipynb
+++ b/01_Generation/00_generate_w_bedrock.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "dc40c48b-0c95-4757-a067-563cfccd51a5",
    "metadata": {
@@ -14,7 +13,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c9a413e2-3c34-4073-9000-d8556537bb6a",
    "metadata": {},
@@ -48,7 +46,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "64baae27-2660-4a1e-b2e5-3de49d069362",
    "metadata": {},
@@ -81,7 +78,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ef38d32a",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -102,6 +101,7 @@
     "import sys\n",
     "\n",
     "import boto3\n",
+    "import botocore\n",
     "\n",
     "module_path = \"..\"\n",
     "sys.path.append(os.path.abspath(module_path))\n",
@@ -122,7 +122,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "4f634211-3de1-4390-8c3f-367af5554c39",
    "metadata": {},
@@ -149,7 +148,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "cc9784e5-5e9d-472d-8ef1-34108ee4968b",
    "metadata": {},
@@ -180,7 +178,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c4ca6751",
    "metadata": {},
@@ -200,7 +197,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "088cf6bf-dd73-4710-a0cc-6c11d220c431",
    "metadata": {},
@@ -209,7 +205,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "379498f2",
    "metadata": {},
@@ -231,11 +226,21 @@
     "modelId = 'amazon.titan-tg1-large' # change this to use a different version from the model provider\n",
     "accept = 'application/json'\n",
     "contentType = 'application/json'\n",
+    "outputText = \"\\n\"\n",
+    "try:\n",
     "\n",
-    "response = boto3_bedrock.invoke_model(body=body, modelId=modelId, accept=accept, contentType=contentType)\n",
-    "response_body = json.loads(response.get('body').read())\n",
+    "    response = boto3_bedrock.invoke_model(body=body, modelId=modelId, accept=accept, contentType=contentType)\n",
+    "    response_body = json.loads(response.get('body').read())\n",
     "\n",
-    "outputText = response_body.get('results')[0].get('outputText')\n"
+    "    outputText = response_body.get('results')[0].get('outputText')\n",
+    "\n",
+    "except botocore.exceptions.ClientError as error:\n",
+    "    \n",
+    "    if error.response['Error']['Code'] == 'AccessDeniedException' and \"Your account is not authorized to invoke this API operation\" in error.response['Error']['Message']:\n",
+    "        print(f\"\\t\\x1b[41mYour account doesn't have access to '{modelId}' model. You need access to continue with the rest of this notebook.\\x1b[0m\\n\")\n",
+    "        \n",
+    "    else:\n",
+    "        raise error\n"
    ]
   },
   {
@@ -255,7 +260,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "2d69e1a0",
    "metadata": {},
@@ -275,23 +279,33 @@
    },
    "outputs": [],
    "source": [
-    "response = boto3_bedrock.invoke_model_with_response_stream(body=body, modelId=modelId, accept=accept, contentType=contentType)\n",
-    "stream = response.get('body')\n",
     "output = []\n",
-    "i = 1\n",
-    "if stream:\n",
-    "    for event in stream:\n",
-    "        chunk = event.get('chunk')\n",
-    "        if chunk:\n",
-    "            chunk_obj = json.loads(chunk.get('bytes').decode())\n",
-    "            text = chunk_obj['outputText']\n",
-    "            output.append(text)\n",
-    "            print(f'\\t\\t\\x1b[31m**Chunk {i}**\\x1b[0m\\n{text}\\n')\n",
-    "            i+=1"
+    "try:\n",
+    "    \n",
+    "    response = boto3_bedrock.invoke_model_with_response_stream(body=body, modelId=modelId, accept=accept, contentType=contentType)\n",
+    "    stream = response.get('body')\n",
+    "    \n",
+    "    i = 1\n",
+    "    if stream:\n",
+    "        for event in stream:\n",
+    "            chunk = event.get('chunk')\n",
+    "            if chunk:\n",
+    "                chunk_obj = json.loads(chunk.get('bytes').decode())\n",
+    "                text = chunk_obj['outputText']\n",
+    "                output.append(text)\n",
+    "                print(f'\\t\\t\\x1b[31m**Chunk {i}**\\x1b[0m\\n{text}\\n')\n",
+    "                i+=1\n",
+    "            \n",
+    "except botocore.exceptions.ClientError as error:\n",
+    "    \n",
+    "    if error.response['Error']['Code'] == 'AccessDeniedException' and \"Your account is not authorized to invoke this API operation\" in error.response['Error']['Message']:\n",
+    "        print(f\"\\t\\x1b[41mYour account doesn't have access to '{modelId}' model. You need access to continue with the rest of this notebook.\\x1b[0m\\n\")\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "9a788be5",
    "metadata": {},
@@ -314,7 +328,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "64b08b3b",
    "metadata": {},
@@ -918,9 +931,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -932,7 +945,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/02_Summarization/01.small-text-summarization-titan.ipynb
+++ b/02_Summarization/01.small-text-summarization-titan.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "fded102b",
    "metadata": {},
@@ -12,7 +11,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "fab8b2cf",
    "metadata": {},
@@ -40,7 +38,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "e9c888b8",
    "metadata": {},
@@ -73,7 +70,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d580e771",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -94,6 +93,7 @@
     "import sys\n",
     "\n",
     "import boto3\n",
+    "import botocore\n",
     "\n",
     "module_path = \"..\"\n",
     "sys.path.append(os.path.abspath(module_path))\n",
@@ -113,7 +113,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "342796d0",
    "metadata": {},
@@ -124,7 +123,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "9da4d9ee",
    "metadata": {},
@@ -190,7 +188,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "3efddbb0",
    "metadata": {},
@@ -220,7 +217,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "cc9f3326",
    "metadata": {},
@@ -243,14 +239,23 @@
     "accept = 'application/json'\n",
     "contentType = 'application/json'\n",
     "\n",
-    "response = boto3_bedrock.invoke_model(body=body, modelId=modelId, accept=accept, contentType=contentType)\n",
-    "response_body = json.loads(response.get('body').read())\n",
+    "try:\n",
+    "    \n",
+    "    response = boto3_bedrock.invoke_model(body=body, modelId=modelId, accept=accept, contentType=contentType)\n",
+    "    response_body = json.loads(response.get('body').read())\n",
     "\n",
-    "print_ww(response_body.get('results')[0].get('outputText'))"
+    "    print_ww(response_body.get('results')[0].get('outputText'))\n",
+    "\n",
+    "except botocore.exceptions.ClientError as error:\n",
+    "    \n",
+    "    if error.response['Error']['Code'] == 'AccessDeniedException' and \"Your account is not authorized to invoke this API operation\" in error.response['Error']['Message']:\n",
+    "        print(f\"\\t\\t\\x1b[41m**Your account doesn't have access to '{modelId}' model. You need access to continue**\\x1b[0m\\n\")\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "3c527882",
    "metadata": {},
@@ -264,17 +269,27 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "62787950",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "response = boto3_bedrock.invoke_model_with_response_stream(body=body, modelId=modelId, accept=accept, contentType=contentType)\n",
-    "stream = response.get('body')\n",
-    "output = list(stream)\n",
-    "output"
+    "try:\n",
+    "    response = boto3_bedrock.invoke_model_with_response_stream(body=body, modelId=modelId, accept=accept, contentType=contentType)\n",
+    "    stream = response.get('body')\n",
+    "    output = list(stream)\n",
+    "    output\n",
+    "\n",
+    "except botocore.exceptions.ClientError as error:\n",
+    "    \n",
+    "    if error.response['Error']['Code'] == 'AccessDeniedException' and \"Your account is not authorized to invoke this API operation\" in error.response['Error']['Message']:\n",
+    "        print(f\"\\t\\t\\x1b[41m**Your account doesn't have access to '{modelId}' model. You need access to continue**\\x1b[0m\\n\")\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "2ec4a584",
    "metadata": {},
@@ -286,7 +301,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ffc08b2e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from IPython.display import display_markdown, Markdown, clear_output"
@@ -296,30 +313,40 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "06b84ff2",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "response = boto3_bedrock.invoke_model_with_response_stream(body=body, modelId=modelId, accept=accept, contentType=contentType)\n",
-    "stream = response.get('body')\n",
-    "output = []\n",
-    "i = 1\n",
-    "if stream:\n",
-    "    for event in stream:\n",
-    "        chunk = event.get('chunk')\n",
-    "        if chunk:\n",
-    "            chunk_obj = json.loads(chunk.get('bytes').decode())\n",
-    "            text = chunk_obj['outputText']\n",
-    "            clear_output(wait=True)\n",
-    "            output.append(text)\n",
-    "            display_markdown(Markdown(''.join(output)))\n",
-    "            i+=1\n",
+    "try:\n",
+    "    response = boto3_bedrock.invoke_model_with_response_stream(body=body, modelId=modelId, accept=accept, contentType=contentType)\n",
+    "    stream = response.get('body')\n",
+    "    output = []\n",
+    "    i = 1\n",
+    "    if stream:\n",
+    "        for event in stream:\n",
+    "            chunk = event.get('chunk')\n",
+    "            if chunk:\n",
+    "                chunk_obj = json.loads(chunk.get('bytes').decode())\n",
+    "                text = chunk_obj['outputText']\n",
+    "                clear_output(wait=True)\n",
+    "                output.append(text)\n",
+    "                display_markdown(Markdown(''.join(output)))\n",
+    "                i+=1\n",
     "\n",
-    "clear_output(wait=True)\n",
-    "print_ww(''.join(output))"
+    "    clear_output(wait=True)\n",
+    "    print_ww(''.join(output))\n",
+    "\n",
+    "except botocore.exceptions.ClientError as error:\n",
+    "    \n",
+    "    if error.response['Error']['Code'] == 'AccessDeniedException' and \"Your account is not authorized to invoke this API operation\" in error.response['Error']['Message']:\n",
+    "        print(f\"\\t\\t\\x1b[41m**Your account doesn't have access to '{modelId}' model. You need access to continue**\\x1b[0m\\n\")\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "62a93aeb",
    "metadata": {},
@@ -915,9 +942,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -929,7 +956,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/02_Summarization/02.long-text-summarization-titan.ipynb
+++ b/02_Summarization/02.long-text-summarization-titan.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "fded102b",
    "metadata": {},
@@ -12,7 +11,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "fab8b2cf",
    "metadata": {},
@@ -39,7 +37,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "fcc7dfe4",
    "metadata": {},
@@ -74,7 +71,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "21948dbb",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -115,7 +114,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "49ae9a41",
    "metadata": {},
@@ -140,9 +138,9 @@
    "outputs": [],
    "source": [
     "from langchain.llms.bedrock import Bedrock\n",
-    "\n",
+    "modelId = \"amazon.titan-tg1-large\"\n",
     "llm = Bedrock(\n",
-    "    model_id=\"amazon.titan-tg1-large\",\n",
+    "    model_id=modelId,\n",
     "    model_kwargs={\n",
     "        \"maxTokenCount\": 4096,\n",
     "        \"stopSequences\": [],\n",
@@ -154,7 +152,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "31223056",
    "metadata": {},
@@ -184,7 +181,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "dc8ec39d",
    "metadata": {},
@@ -233,7 +229,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "a5f8ae45",
    "metadata": {},
@@ -242,7 +237,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "b61d49f5",
    "metadata": {},
@@ -271,7 +265,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "4f0eda5e-36a5-4618-ac5a-e272673d6f26",
    "metadata": {},
@@ -288,7 +281,18 @@
    },
    "outputs": [],
    "source": [
-    "output = summary_chain.run(docs)"
+    "output = \"\"\n",
+    "try:\n",
+    "    \n",
+    "    output = summary_chain.run(docs)\n",
+    "\n",
+    "except ValueError as error:\n",
+    "\n",
+    "    if  \"Your account is not authorized to invoke this API operation\" in str(error):\n",
+    "        print(f\"\\t\\t\\x1b[41m**Your account doesn't have access to '{modelId}' model. You need access to continue**\\x1b[0m\\n\")\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
@@ -302,6 +306,14 @@
    "source": [
     "print_ww(output.strip())"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee815e56-6ac6-44c4-bb61-5b6b7d08e847",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -882,9 +894,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -896,7 +908,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/03_QuestionAnswering/00_qa_w_bedrock_titan.ipynb
+++ b/03_QuestionAnswering/00_qa_w_bedrock_titan.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -28,7 +27,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -42,7 +40,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%pip install --no-build-isolation --force-reinstall \\\n",
@@ -56,7 +56,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -66,7 +68,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import json\n",
@@ -74,6 +78,8 @@
     "import sys\n",
     "\n",
     "import boto3\n",
+    "import botocore\n",
+    "\n",
     "\n",
     "module_path = \"..\"\n",
     "sys.path.append(os.path.abspath(module_path))\n",
@@ -93,7 +99,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -102,7 +107,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -120,7 +124,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -143,7 +146,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "prompt_data = \"\"\"You are an helpful assistant. Answer questions in a concise way. If you are unsure about the\n",
@@ -160,7 +165,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -170,24 +174,40 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "body = json.dumps({\"inputText\": prompt_data, \"textGenerationConfig\": parameters})\n",
     "modelId = \"amazon.titan-tg1-large\"  # change this to use a different version from the model provider\n",
     "accept = \"application/json\"\n",
     "contentType = \"application/json\"\n",
+    "try:\n",
+    "    \n",
+    "    response = boto3_bedrock.invoke_model(\n",
+    "        body=body, modelId=modelId, accept=accept, contentType=contentType\n",
+    "    )\n",
+    "    response_body = json.loads(response.get(\"body\").read())\n",
+    "    answer = response_body.get(\"results\")[0].get(\"outputText\")\n",
+    "    print_ww(answer.strip())\n",
     "\n",
-    "response = boto3_bedrock.invoke_model(\n",
-    "    body=body, modelId=modelId, accept=accept, contentType=contentType\n",
-    ")\n",
-    "response_body = json.loads(response.get(\"body\").read())\n",
-    "answer = response_body.get(\"results\")[0].get(\"outputText\")\n",
-    "print_ww(answer.strip())"
+    "except botocore.exceptions.ClientError as error:\n",
+    "    \n",
+    "    if error.response['Error']['Code'] == 'AccessDeniedException' and \"Your account is not authorized to invoke this API operation\" in error.response['Error']['Message']:\n",
+    "        print(f\"\\t\\x1b[41mYour account doesn't have access to '{modelId}' model. You need access to continue with the rest of this notebook.\\x1b[0m\\n\")\n",
+    "        \n",
+    "        class StopExecution(Exception):\n",
+    "            def _render_traceback_(self):\n",
+    "                pass\n",
+    "\n",
+    "        raise StopExecution\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -199,11 +219,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "prompt_data = \"How can I fix a flat tire on my Amazon Tirana?\"\n",
-    "body = json.dumps({\"inputText\": prompt_data, \"textGenerationConfig\": parameters})\n",
+    "body = json.dumps({\"inputText\": prompt_data, \n",
+    "                   \"textGenerationConfig\": parameters})\n",
     "modelId = \"amazon.titan-tg1-large\"  # change this to use a different version from the model provider\n",
     "accept = \"application/json\"\n",
     "contentType = \"application/json\"\n",
@@ -217,7 +240,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -319,7 +341,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -343,7 +364,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -370,7 +390,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -411,7 +430,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -999,9 +1017,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1013,7 +1031,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/03_QuestionAnswering/01_qa_w_rag_claude.ipynb
+++ b/03_QuestionAnswering/01_qa_w_rag_claude.ipynb
@@ -203,7 +203,10 @@
     "\n",
     "# - create the Anthropic Model\n",
     "llm = Bedrock(model_id=\"anthropic.claude-v2\", client=boto3_bedrock, model_kwargs={'max_tokens_to_sample':200})\n",
-    "bedrock_embeddings = BedrockEmbeddings(model_id=\"amazon.titan-embed-g1-text-02\", client=boto3_bedrock)"
+    "modelId = \"amazon.titan-embed-g1-text-02\"\n",
+    "#modelId = \"amazon.titan-embed-text-v1\"\n",
+    "bedrock_embeddings = BedrockEmbeddings(model_id=modelId, client=boto3_bedrock)\n",
+    "print(bedrock_embeddings.model_id)"
    ]
   },
   {
@@ -301,9 +304,25 @@
    },
    "outputs": [],
    "source": [
-    "sample_embedding = np.array(bedrock_embeddings.embed_query(docs[0].page_content))\n",
-    "print(\"Sample embedding of a document chunk: \", sample_embedding)\n",
-    "print(\"Size of the embedding: \", sample_embedding.shape)"
+    "try:\n",
+    "    \n",
+    "    sample_embedding = np.array(bedrock_embeddings.embed_query(docs[0].page_content))\n",
+    "    print(\"Sample embedding of a document chunk: \", sample_embedding)\n",
+    "    print(\"Size of the embedding: \", sample_embedding.shape)\n",
+    "\n",
+    "except ValueError as error:\n",
+    "\n",
+    "    if  \"Your account is not authorized to invoke this API operation\" in str(error):\n",
+    "        print(f\"\\t\\x1b[41mYour account doesn't have access to '{modelId}' model. You need access to continue with the rest of this notebook.\\x1b[0m\\n\")\n",
+    "        \n",
+    "        class StopExecution(ValueError):\n",
+    "            def _render_traceback_(self):\n",
+    "                pass\n",
+    "\n",
+    "        raise StopExecution\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
@@ -1180,9 +1199,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1194,7 +1213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/03_QuestionAnswering/02_qa_w_rag_claude_pinecone.ipynb
+++ b/03_QuestionAnswering/02_qa_w_rag_claude_pinecone.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -11,7 +10,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -50,7 +48,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -68,7 +65,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -97,7 +93,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -161,7 +156,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import json\n",
@@ -188,7 +185,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -212,7 +208,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# We will be using the Titan Embeddings Model to generate our Embeddings.\n",
@@ -227,7 +225,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -238,7 +235,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from urllib.request import urlretrieve\n",
@@ -255,7 +254,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -267,7 +265,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -314,13 +314,30 @@
    },
    "outputs": [],
    "source": [
-    "sample_embedding = np.array(bedrock_embeddings.embed_query(docs[0].page_content))\n",
-    "print(\"Sample embedding of a document chunk: \", sample_embedding)\n",
-    "print(\"Size of the embedding: \", sample_embedding.shape)"
+    "try:\n",
+    "    \n",
+    "    sample_embedding = np.array(bedrock_embeddings.embed_query(docs[0].page_content))\n",
+    "    modelId = bedrock_embeddings.model_id\n",
+    "    print(\"Embedding model Id :\", modelId)\n",
+    "    print(\"Sample embedding of a document chunk: \", sample_embedding)\n",
+    "    print(\"Size of the embedding: \", sample_embedding.shape)\n",
+    "\n",
+    "except ValueError as error:\n",
+    "\n",
+    "    if  \"Your account is not authorized to invoke this API operation\" in str(error):\n",
+    "        print(f\"\\t\\x1b[41mYour account doesn't have access to '{modelId}' model. You need access to continue with the rest of this notebook.\\x1b[0m\\n\")\n",
+    "        \n",
+    "        class StopExecution(ValueError):\n",
+    "            def _render_traceback_(self):\n",
+    "                pass\n",
+    "\n",
+    "        raise StopExecution\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -371,7 +388,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -434,7 +450,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -462,7 +477,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -486,7 +500,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -494,7 +507,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -517,7 +529,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -536,7 +547,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -574,7 +584,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -584,7 +593,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -593,7 +601,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -643,7 +650,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1253,9 +1259,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "tmp-bedrock",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1267,7 +1273,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/04_Chatbot/00_Chatbot_AI21.ipynb
+++ b/04_Chatbot/00_Chatbot_AI21.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -13,7 +12,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -55,7 +53,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -81,7 +78,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -95,7 +91,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%pip install --quiet \"faiss-cpu>=1.7,<2\" \"ipywidgets>=7,<8\" langchain==0.0.309 \"pypdf>=3.8,<4\""
@@ -114,7 +112,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import json\n",
@@ -141,7 +141,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -149,7 +148,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -172,18 +170,33 @@
     "from langchain.chains import ConversationChain\n",
     "from langchain.llms.bedrock import Bedrock\n",
     "from langchain.memory import ConversationBufferMemory\n",
-    "\n",
-    "ai21_llm = Bedrock(model_id=\"ai21.j2-jumbo-instruct\", client=boto3_bedrock)\n",
+    "modelId = \"ai21.j2-jumbo-instruct\"\n",
+    "ai21_llm = Bedrock(model_id=modelId, client=boto3_bedrock)\n",
     "memory = ConversationBufferMemory()\n",
     "conversation = ConversationChain(\n",
     "    llm=ai21_llm, verbose=True, memory=memory\n",
     ")\n",
     "\n",
-    "print_ww(conversation.predict(input=\"Hi there!\"))"
+    "try:\n",
+    "    \n",
+    "    print_ww(conversation.predict(input=\"Hi there!\"))\n",
+    "\n",
+    "except ValueError as error:\n",
+    "\n",
+    "    if  \"Your account is not authorized to invoke this API operation\" in str(error):\n",
+    "        print(f\"\\t\\x1b[41mYour account doesn't have access to '{modelId}' model. You need access to continue with the rest of this notebook.\\x1b[0m\\n\")\n",
+    "        \n",
+    "        class StopExecution(ValueError):\n",
+    "            def _render_traceback_(self):\n",
+    "                pass\n",
+    "\n",
+    "        raise StopExecution\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -204,7 +217,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -225,7 +237,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -244,7 +255,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -252,7 +262,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -283,7 +292,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import ipywidgets as ipw\n",
@@ -340,7 +351,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -350,7 +360,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "chat = ChatUX(qa)\n",
@@ -358,7 +370,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -368,7 +379,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -395,7 +405,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -415,7 +424,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -424,7 +432,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -447,12 +454,12 @@
     "from langchain.embeddings import BedrockEmbeddings\n",
     "from langchain.vectorstores import FAISS\n",
     "from langchain import PromptTemplate\n",
-    "\n",
-    "br_embeddings = BedrockEmbeddings(model_id=\"amazon.titan-embed-g1-text-02\", client=boto3_bedrock)"
+    "modelId = \"amazon.titan-embed-g1-text-02\"\n",
+    "#modelId = \"amazon.titan-embed-text-v1\"\n",
+    "br_embeddings = BedrockEmbeddings(model_id=modelId, client=boto3_bedrock)"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -487,18 +494,33 @@
     "docs = CharacterTextSplitter(chunk_size=2000, chunk_overlap=400, separator=\",\").split_documents(documents_aws)\n",
     "\n",
     "print(f\"Documents:after split and chunking size={len(docs)}\")\n",
+    "vectorstore_faiss_aws = None\n",
+    "try:\n",
+    "    \n",
+    "    vectorstore_faiss_aws = FAISS.from_documents(\n",
+    "        documents=docs,\n",
+    "        embedding = br_embeddings, \n",
+    "        #**k_args\n",
+    "    )\n",
     "\n",
-    "vectorstore_faiss_aws = FAISS.from_documents(\n",
-    "    documents=docs,\n",
-    "    embedding = br_embeddings, \n",
-    "    #**k_args\n",
-    ")\n",
+    "    print(f\"vectorstore_faiss_aws:created={vectorstore_faiss_aws}::\")\n",
     "\n",
-    "print(f\"vectorstore_faiss_aws:created={vectorstore_faiss_aws}::\")"
+    "except ValueError as error:\n",
+    "\n",
+    "    if  \"Your account is not authorized to invoke this API operation\" in str(error):\n",
+    "        print(f\"\\t\\x1b[41mYour account doesn't have access to '{modelId}' model. You need access to continue with the rest of this notebook.\\x1b[0m\\n\")\n",
+    "        \n",
+    "        class StopExecution(ValueError):\n",
+    "            def _render_traceback_(self):\n",
+    "                pass\n",
+    "\n",
+    "        raise StopExecution\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -520,7 +542,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -561,7 +582,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -615,7 +635,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -633,7 +652,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1227,9 +1245,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1241,7 +1259,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/04_Chatbot/00_Chatbot_Claude.ipynb
+++ b/04_Chatbot/00_Chatbot_Claude.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -13,7 +12,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -55,7 +53,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -69,7 +66,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%pip install --no-build-isolation --force-reinstall \\\n",
@@ -79,7 +78,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -93,7 +91,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%pip install --quiet \"faiss-cpu>=1.7,<2\" \"ipywidgets>=7,<8\" langchain==0.0.309 \"pypdf>=3.8,<4\""
@@ -102,7 +102,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -112,7 +114,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import json\n",
@@ -140,7 +144,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -166,9 +169,9 @@
     "from langchain.chains import ConversationChain\n",
     "from langchain.llms.bedrock import Bedrock\n",
     "from langchain.memory import ConversationBufferMemory\n",
-    "\n",
+    "modelId = \"anthropic.claude-v2\"\n",
     "cl_llm = Bedrock(\n",
-    "    model_id=\"anthropic.claude-v2\",\n",
+    "    model_id=modelId,\n",
     "    client=boto3_bedrock,\n",
     "    model_kwargs={\"max_tokens_to_sample\": 1000},\n",
     ")\n",
@@ -177,11 +180,26 @@
     "    llm=cl_llm, verbose=True, memory=memory\n",
     ")\n",
     "\n",
-    "print_ww(conversation.predict(input=\"Hi there!\"))"
+    "try:\n",
+    "    \n",
+    "    print_ww(conversation.predict(input=\"Hi there!\"))\n",
+    "\n",
+    "except ValueError as error:\n",
+    "\n",
+    "    if  \"Your account is not authorized to invoke this API operation\" in str(error):\n",
+    "        print(f\"\\t\\x1b[41mYour account doesn't have access to '{modelId}' model. You need access to continue with the rest of this notebook.\\x1b[0m\\n\")\n",
+    "        \n",
+    "        class StopExecution(ValueError):\n",
+    "            def _render_traceback_(self):\n",
+    "                pass\n",
+    "\n",
+    "        raise StopExecution\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -191,7 +209,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -199,7 +216,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -248,7 +264,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -269,7 +284,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -281,14 +295,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "print_ww(conversation.predict(input=\"Cool. Will that work with tomatoes?\"))"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -298,14 +313,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "print_ww(conversation.predict(input=\"That's all, thank you!\"))"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -313,7 +329,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -325,7 +340,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import ipywidgets as ipw\n",
@@ -382,7 +399,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -396,7 +412,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "chat = ChatUX(conversation)\n",
@@ -404,7 +422,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -414,7 +431,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -446,14 +462,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "print_ww(conversation.predict(input=\"What these people really do? Is it fun?\"))"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -473,7 +490,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -484,7 +500,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -502,17 +517,18 @@
     "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "from langchain.embeddings import BedrockEmbeddings\n",
-    "\n",
-    "br_embeddings = BedrockEmbeddings(model_id=\"amazon.titan-embed-g1-text-02\", client=boto3_bedrock)"
+    "modelId = \"amazon.titan-embed-g1-text-02\"\n",
+    "#modelId = \"amazon.titan-embed-text-v1\"\n",
+    "br_embeddings = BedrockEmbeddings(model_id=modelId, client=boto3_bedrock)"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -548,17 +564,32 @@
     "docs = CharacterTextSplitter(chunk_size=2000, chunk_overlap=400, separator=\",\").split_documents(documents_aws)\n",
     "\n",
     "print(f\"Number of documents after split and chunking={len(docs)}\")\n",
+    "vectorstore_faiss_aws = None\n",
+    "try:\n",
+    "    \n",
+    "    vectorstore_faiss_aws = FAISS.from_documents(\n",
+    "        documents=docs,\n",
+    "        embedding = br_embeddings\n",
+    "    )\n",
     "\n",
-    "vectorstore_faiss_aws = FAISS.from_documents(\n",
-    "    documents=docs,\n",
-    "    embedding = br_embeddings\n",
-    ")\n",
+    "    print(f\"vectorstore_faiss_aws: number of elements in the index={vectorstore_faiss_aws.index.ntotal}::\")\n",
     "\n",
-    "print(f\"vectorstore_faiss_aws: number of elements in the index={vectorstore_faiss_aws.index.ntotal}::\")\n"
+    "except ValueError as error:\n",
+    "\n",
+    "    if  \"Your account is not authorized to invoke this API operation\" in str(error):\n",
+    "        print(f\"\\t\\x1b[41mYour account doesn't have access to '{modelId}' model. You need access to continue with the rest of this notebook.\\x1b[0m\\n\")\n",
+    "        \n",
+    "        class StopExecution(ValueError):\n",
+    "            def _render_traceback_(self):\n",
+    "                pass\n",
+    "\n",
+    "        raise StopExecution\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -580,7 +611,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -604,7 +634,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -630,7 +659,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -671,7 +699,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -691,7 +718,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -772,7 +798,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -793,7 +818,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -803,7 +827,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1397,9 +1420,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1411,7 +1434,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/04_Chatbot/00_Chatbot_Titan.ipynb
+++ b/04_Chatbot/00_Chatbot_Titan.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -13,7 +12,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -55,7 +53,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -69,7 +66,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%pip install --no-build-isolation --force-reinstall \\\n",
@@ -79,7 +78,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -93,7 +91,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%pip install --quiet \"faiss-cpu>=1.7,<2\" \"ipywidgets>=7,<8\" langchain==0.0.309 \"pypdf>=3.8,<4\""
@@ -102,7 +102,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -112,7 +114,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import json\n",
@@ -139,7 +143,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -163,8 +166,8 @@
     "from langchain.chains import ConversationChain\n",
     "from langchain.llms.bedrock import Bedrock\n",
     "from langchain.memory import ConversationBufferMemory\n",
-    "\n",
-    "titan_llm = Bedrock(model_id=\"amazon.titan-tg1-large\", client=boto3_bedrock)\n",
+    "modelId = \"amazon.titan-tg1-large\"\n",
+    "titan_llm = Bedrock(model_id=modelId, client=boto3_bedrock)\n",
     "titan_llm.model_kwargs = {'temperature': 0.5, \"maxTokenCount\": 700}\n",
     "\n",
     "memory = ConversationBufferMemory()\n",
@@ -176,11 +179,26 @@
     ")\n",
     "conversation.prompt.template = \"\"\"System: The following is a friendly conversation between a knowledgeable helpful assistant and a customer. The assistant is talkative and provides lots of specific details from it's context.\\n\\nCurrent conversation:\\n{history}\\nUser: {input}\\nBot:\"\"\"\n",
     "\n",
-    "print_ww(conversation.predict(input=\"Hi there!\"))"
+    "try:\n",
+    "    \n",
+    "    print_ww(conversation.predict(input=\"Hi there!\"))\n",
+    "\n",
+    "except ValueError as error:\n",
+    "\n",
+    "    if  \"Your account is not authorized to invoke this API operation\" in str(error):\n",
+    "        print(f\"\\t\\x1b[41mYour account doesn't have access to '{modelId}' model. You need access to continue with the rest of this notebook.\\x1b[0m\\n\")\n",
+    "        \n",
+    "        class StopExecution(ValueError):\n",
+    "            def _render_traceback_(self):\n",
+    "                pass\n",
+    "\n",
+    "        raise StopExecution\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -201,7 +219,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -222,7 +239,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -241,7 +257,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -249,7 +264,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -342,7 +356,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -360,7 +373,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -370,7 +382,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -397,7 +408,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -417,7 +427,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -426,7 +435,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -454,7 +462,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -462,7 +469,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -508,7 +514,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -530,7 +535,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -571,7 +575,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -625,7 +628,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -643,7 +645,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1237,9 +1238,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "conda_python3"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1251,7 +1252,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/07_Agents/00_LLM_Claude_Agent_Tools.ipynb
+++ b/07_Agents/00_LLM_Claude_Agent_Tools.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -18,7 +17,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -27,7 +25,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -37,7 +34,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%pip install --no-build-isolation --force-reinstall \\\n",
@@ -56,13 +55,15 @@
    "source": [
     "# Make sure you ran `download-dependencies.sh` from the root of the repository first!\n",
     "\n",
-    "%pip install --quiet langchain==0.0.309 google-search-results"
+    "%pip install --quiet langchain==0.0.309 google-search-results wikipedia"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -112,7 +113,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -143,7 +143,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from langchain.llms.bedrock import Bedrock\n",
@@ -172,32 +174,34 @@
    "source": [
     "llm = BedrockModelWrapper(model_id=\"anthropic.claude-instant-v1\", client=boto3_bedrock, model_kwargs=model_parameter)\n",
     "\n",
-    "tools = load_tools([\"serpapi\", \"llm-math\"], llm=llm)\n",
+    "tools = load_tools([\"wikipedia\", \"llm-math\"], llm=llm)\n",
     "react_agent = initialize_agent(tools, \n",
     "                               llm, \n",
     "                               agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, \n",
     "                               verbose=True,\n",
-    "                            #    max_iteration=2,\n",
-    "                            #    return_intermediate_steps=True,\n",
-    "                            #    handle_parsing_errors=True,\n",
+    "                                max_iteration=2,\n",
+    "                                #return_intermediate_steps=True,\n",
+    "                                handle_parsing_errors=True,\n",
     "                               )\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "prompt_template = \"\"\"Use the following format:\n",
     "Question: the input question you must answer\n",
     "Thought: you should always think about what to do, Also try to follow steps mentioned above\n",
-    "Action: the action to take, should be one of [\"serpapi\", \"llm-math\"]\n",
+    "Action: the action to take, should be one of [\"Wikipedia\", \"llm-math\"]\n",
     "Action Input: the input to the action\n",
     "Observation: the result of the action\n",
     "... (this Thought/Action/Action Input/Observation can repeat N times)\n",
     "Thought: I now know the final answer\n",
-    "Final Answer: the final answer to the original input question\n",
+    "Final Answer: the final answer to the original input question. Stop after getting the final answer.\n",
     "\n",
     "Question: {input}\n",
     "\n",
@@ -208,7 +212,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "react_agent.agent.llm_chain.prompt.template=prompt_template"
@@ -217,7 +223,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "question = \"What is Amazon SageMaker? What is the launch year multiplied by 2\""
@@ -235,7 +243,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -262,12 +269,14 @@
     "\n",
     "Write a python function named list_tagged_instances with one parameter named tagname. \n",
     "\n",
-    "The function queries the boto3 library to return a list all of the EC2 instances that have a tag equal to the tagname parameter. \n",
+    "The function queries the boto3 library to return a list all of the EC2 instances that have a tag-key equal to the tagname parameter. \n",
+    "\n",
+    "Write another python function named delete_instance with one parameter named instance_id. \n",
     "\n",
     "return the code inside <code></code>.\n",
     "Assistant:\"\"\"\n",
     "\n",
-    "body = json.dumps({\"prompt\": prompt_data, \"max_tokens_to_sample\": 500})\n",
+    "body = json.dumps({\"prompt\": prompt_data, \"temperature\":0, \"max_tokens_to_sample\": 500})\n",
     "modelId = \"anthropic.claude-instant-v1\"  \n",
     "accept = \"application/json\"\n",
     "contentType = \"application/json\"\n",
@@ -287,7 +296,63 @@
    ]
   },
   {
-   "attachments": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "\n",
+    "ec2 = boto3.client('ec2')\n",
+    "\n",
+    "def list_tagged_instances(tagname):\n",
+    "    response = ec2.describe_instances(\n",
+    "        Filters=[\n",
+    "            {\n",
+    "                'Name': 'tag-key',\n",
+    "                'Values': [tagname]\n",
+    "            }\n",
+    "        ]\n",
+    "    )\n",
+    "    instances = []\n",
+    "    for reservation in response[\"Reservations\"]:\n",
+    "        for instance in reservation[\"Instances\"]:\n",
+    "            instances.append(instance[\"InstanceId\"])\n",
+    "    return instances\n",
+    "\n",
+    "def delete_instance(instance_id):\n",
+    "    ec2.terminate_instances(InstanceIds=[instance_id])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "list_tagged_instances('delete')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "tools.append(Tool.from_function(\n",
+    "        name=\"EC2Search\",\n",
+    "        func=list_tagged_instances,  # Mock Function, replace with an api call\n",
+    "        description=\"List EC2 instances with delete tag\"\n",
+    "    ))"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -313,9 +378,7 @@
     "\n",
     "react_agent = initialize_agent(tools, llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True)\n",
     "\n",
-    "question = \"\"\"Human: Please list my EC2 instances with the a tag delete. \n",
-    "Next, patch each of the instances and record the patch change record in the CMDB with a change type of 'PATCH'. \n",
-    "Finally, for each of the instances stop the instance and tell me how many were stopped. \n",
+    "question = \"\"\"Human: list EC2 instances with 'delete' as input parameter\n",
     "Assistant:\"\"\"\n",
     "\n",
     "result = react_agent.run(question)\n",
@@ -324,7 +387,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -351,7 +413,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -483,9 +544,21 @@
    },
    "outputs": [],
    "source": [
-    "react_agent = initialize_agent(tools, llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True)\n",
+    "react_agent = initialize_agent(tools, llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True, handle_parsing_errors=True,max_iteration=2)\n",
     "\n",
-    "question = \"\"\"\\n\\nHuman: write one sentence summary about the information you know about the customer with an id of 2.\n",
+    "question = \"\"\"\\n\\nHuman: write one sentence summary about the information you know about the customer with an id of 2. \n",
+    "\n",
+    "Action: the action to take, should be CustomerLookup\n",
+    "\n",
+    "Action Input: the input to the action\n",
+    "\n",
+    "Observation: the result of the action\n",
+    "\n",
+    "Thought: I now know the final answer\n",
+    "\n",
+    "Action: Summarize the final answer\n",
+    "\n",
+    "Final Answer: the final answer to the original input question. Stop after getting the final answer.\n",
     "\n",
     "\\n\\nAssistant: Here is the one sentence summary: \"\"\"\n",
     "\n",
@@ -493,13 +566,596 @@
     "\n",
     "print(f\"{result}\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
+  "availableInstances": [
+   {
+    "_defaultOrder": 0,
+    "_isFastLaunch": true,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 4,
+    "name": "ml.t3.medium",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 1,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 8,
+    "name": "ml.t3.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 2,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.t3.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 3,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.t3.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 4,
+    "_isFastLaunch": true,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 8,
+    "name": "ml.m5.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 5,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.m5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 6,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.m5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 7,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.m5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 8,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.m5.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 9,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.m5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 10,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.m5.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 11,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 384,
+    "name": "ml.m5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 12,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 8,
+    "name": "ml.m5d.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 13,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.m5d.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 14,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.m5d.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 15,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.m5d.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 16,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.m5d.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 17,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.m5d.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 18,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.m5d.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 19,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 384,
+    "name": "ml.m5d.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 20,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": true,
+    "memoryGiB": 0,
+    "name": "ml.geospatial.interactive",
+    "supportedImageNames": [
+     "sagemaker-geospatial-v1-0"
+    ],
+    "vcpuNum": 0
+   },
+   {
+    "_defaultOrder": 21,
+    "_isFastLaunch": true,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 4,
+    "name": "ml.c5.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 22,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 8,
+    "name": "ml.c5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 23,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.c5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 24,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.c5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 25,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 72,
+    "name": "ml.c5.9xlarge",
+    "vcpuNum": 36
+   },
+   {
+    "_defaultOrder": 26,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 96,
+    "name": "ml.c5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 27,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 144,
+    "name": "ml.c5.18xlarge",
+    "vcpuNum": 72
+   },
+   {
+    "_defaultOrder": 28,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.c5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 29,
+    "_isFastLaunch": true,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.g4dn.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 30,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.g4dn.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 31,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.g4dn.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 32,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.g4dn.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 33,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.g4dn.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 34,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.g4dn.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 35,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 61,
+    "name": "ml.p3.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 36,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 244,
+    "name": "ml.p3.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 37,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 488,
+    "name": "ml.p3.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 38,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 768,
+    "name": "ml.p3dn.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 39,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.r5.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 40,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.r5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 41,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.r5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 42,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.r5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 43,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.r5.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 44,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 384,
+    "name": "ml.r5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 45,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 512,
+    "name": "ml.r5.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 46,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 768,
+    "name": "ml.r5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 47,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.g5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 48,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.g5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 49,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.g5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 50,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.g5.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 51,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.g5.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 52,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.g5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 53,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 384,
+    "name": "ml.g5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 54,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 768,
+    "name": "ml.g5.48xlarge",
+    "vcpuNum": 192
+   },
+   {
+    "_defaultOrder": 55,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 1152,
+    "name": "ml.p4d.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 56,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 1152,
+    "name": "ml.p4de.24xlarge",
+    "vcpuNum": 96
+   }
+  ],
+  "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -511,7 +1167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added code to handle exceptions arising from invocations of Amazon Bedrock Titan and Embedding models when those models are Unavailable in the account. The following 10 files are affected.

bedrock_boto3_setup.ipynb
00_generate_w_bedrock.ipynb
01.small-text-summarization-titan.ipynb
02.long-text-summarization-titan.ipynb
00_qa_w_bedrock_titan.ipynb
01_qa_w_rag_claude.ipynb
02_qa_w_rag_claude_pinecone.ipynb
00_Chatbot_AI21.ipynb
00_Chatbot_Claude.ipynb
00_Chatbot_Titan.ipynb

The following file has been  modified to remove dependency on SerpAPI; Instead Wikipedia search has been added. In addition, code to register EC2Search function to Agent Tool has been added.

00_LLM_Claude_Agent_Tools.ipynb

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
