### PR TITLE
Update bedrock_boto3_setup.ipynb

### DIFF
--- a/00_Intro/bedrock_boto3_setup.ipynb
+++ b/00_Intro/bedrock_boto3_setup.ipynb
@@ -25,9 +25,7 @@
    "source": [
     "## Prerequisites\n",
     "\n",
-    "⚠️ You should already have run the [../download-dependencies.sh script](../download-dependencies.sh) to fetch the SDK packages required for using Bedrock.\n",
-    "\n",
-    "Once the packages are ready, you'll need to run the below cell to install them in the notebook kernel:"
+    "Run the below cell to install updated libraries in the notebook kernel:"
    ]
   },
   {


### PR DESCRIPTION
Removed references to downlooad_dependencies.sh n bedrock_boto3_setup.ipynb

*Issue #, if available:* 68

*Description of changes:* removed references to download_dependencies.sh since these are no longer required. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
