### PR TITLE
Added Anthropic Claude Streaming Example with required prompt_data

### DIFF
--- a/00_Intro/bedrock_boto3_setup.ipynb
+++ b/00_Intro/bedrock_boto3_setup.ipynb
@@ -726,6 +726,76 @@
   },
   {
    "cell_type": "markdown",
+   "id": "adf097eb-1bfa-41f1-8135-cdd4ad6e9983",
+   "metadata": {},
+   "source": [
+    "### Anthropic Claude"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd800ef5-78f7-43d4-b73e-c37c7609cb40",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# If you'd like to try your own prompt, edit this parameter!\n",
+    "prompt_data = \"\"\"Human: Write me a blog about making strong business decisions as a leader.\n",
+    "\n",
+    "Assistant:\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be7fbbe8-78b8-4071-b80c-3f954185fad8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from IPython.display import clear_output, display, display_markdown, Markdown\n",
+    "\n",
+    "body = json.dumps({\"prompt\": prompt_data, \"max_tokens_to_sample\": 500})\n",
+    "modelId = \"anthropic.claude-instant-v1\"  # (Change this to try different model versions)\n",
+    "accept = \"application/json\"\n",
+    "contentType = \"application/json\"\n",
+    "\n",
+    "try:\n",
+    "    \n",
+    "    response = bedrock_runtime.invoke_model_with_response_stream(\n",
+    "        body=body, modelId=modelId, accept=accept, contentType=contentType\n",
+    "    )\n",
+    "    stream = response.get('body')\n",
+    "    output = []\n",
+    "\n",
+    "    if stream:\n",
+    "        for event in stream:\n",
+    "            chunk = event.get('chunk')\n",
+    "            if chunk:\n",
+    "                chunk_obj = json.loads(chunk.get('bytes').decode())\n",
+    "                text = chunk_obj['completion']\n",
+    "                clear_output(wait=True)\n",
+    "                output.append(text)\n",
+    "                display_markdown(Markdown(''.join(output)))\n",
+    "            \n",
+    "except botocore.exceptions.ClientError as error:\n",
+    "    \n",
+    "    if error.response['Error']['Code'] == 'AccessDeniedException':\n",
+    "           print(f\"\\x1b[41m{error.response['Error']['Message']}\\\n",
+    "                \\nTo troubeshoot this issue please refer to the following resources.\\\n",
+    "                 \\nhttps://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_access-denied.html\\\n",
+    "                 \\nhttps://docs.aws.amazon.com/bedrock/latest/userguide/security-iam.html\\x1b[0m\\n\")\n",
+    "        \n",
+    "    else:\n",
+    "        raise error"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1ef3451d-b66a-4b11-a1ed-734bf9e7bbec",
    "metadata": {},
    "source": [
@@ -1415,7 +1485,7 @@
   "kernelspec": {
    "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-310-v1"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
*Issue #, if available:*
  nothing
*Description of changes:*
  An example of generating streaming output for Anthropic Claude is added to the next cell of the TITAN example cell.
The following three points are different from TITAN.

- prompt_data (Claude needs Human/Assistant format)
- body
- modelId
- JSON key of chunk_obj (TITAN: outputText -> Claude: completion)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

 I failed to update the previous pull request( https://github.com/aws-samples/amazon-bedrock-workshop/pull/83 ), so I submitted a new pull request reflecting the review comments.
