### PR TITLE
Update bedrock_boto3_setup.ipynb

### DIFF
--- a/00_Intro/bedrock_boto3_setup.ipynb
+++ b/00_Intro/bedrock_boto3_setup.ipynb
@@ -177,7 +177,7 @@
     "%pip install -qU --no-cache-dir nemoguardrails==0.5.0\n",
     "\n",
     "%pip install -qU \"faiss-cpu>=1.7,<2\" \\\n",
-    "                      \"langchain==0.0.308\" \\\n",
+    "                      \"langchain==0.0.309\" \\\n",
     "                      \"pypdf>=3.8,<4\" \\\n",
     "                      \"ipywidgets>=7,<8\"\n"
    ]


### PR DESCRIPTION
changed langchain version to langchain==0.0.309

*Issue #, if available:*

*Description of changes:*
new version is langchain==0.0.309

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
