### PR TITLE
Update bedrock_boto3_setup.ipynb

### DIFF
--- a/00_Intro/bedrock_boto3_setup.ipynb
+++ b/00_Intro/bedrock_boto3_setup.ipynb
@@ -23,7 +23,9 @@
    "source": [
     "## Prerequisites\n",
     "\n",
-    "Run the cells in this section to install the needed packages for workshop"
+    "Run the cells in this section to install the needed packages for workshop. ⚠️ **You will see Pip Dependency Errors that are safe ignore** ⚠️\n",
+    "\n",
+    "`IGNORE ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.`"
    ]
   },
   {


### PR DESCRIPTION
added a note to ignore errors 
 
IGNORE ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.

*Issue #, if available:*

*Description of changes:*
edited cell to ignore errors related Pip Dependency Errors

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
