### PR TITLE
switched from bedrock to bedrock-runtime

### DIFF
--- a/06_CodeGeneration/01_sql_query_generate_w_bedrock.ipynb
+++ b/06_CodeGeneration/01_sql_query_generate_w_bedrock.ipynb
@@ -85,6 +85,7 @@
     "boto3_bedrock = bedrock.get_bedrock_client(\n",
     "    assumed_role=os.environ.get(\"BEDROCK_ASSUME_ROLE\", None),\n",
     "    region=os.environ.get(\"AWS_DEFAULT_REGION\", None),\n",
+    "    runtime=True\n",
     ")"
    ]
   },


### PR DESCRIPTION
Fixes the following error when running this notebook as is: 

AttributeError: 'Bedrock' object has no attribute 'invoke_model'

Note this issue still occurs after running the following: https://github.com/aws-samples/amazon-bedrock-workshop/blob/109ed616fd14c9eb26eda9bef96eb78c490d5ef6/00_Intro/bedrock_boto3_setup.ipynb#Prerequisites

Note also that this change has been reproduced and confirmed to fix the issue. Not sure if the issue is more widespread across this repo, but does affect this file. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
