### PR TITLE
Corrected OpenSearch spelling in 02_qa_w_rag_claude_opensearch.ipynb

### DIFF
--- a/03_QuestionAnswering/02_qa_w_rag_claude_opensearch.ipynb
+++ b/03_QuestionAnswering/02_qa_w_rag_claude_opensearch.ipynb
@@ -340,7 +340,7 @@
    "source": [
     "Following the similar pattern embeddings could be generated for the entire corpus and stored in a vector store.\n",
     "\n",
-    "Firt of all we have to create a vector store. In this workshop we will use ***Amazon OpenSearch serverless.***\n",
+    "First of all we have to create a vector store. In this workshop we will use ***Amazon OpenSearch serverless.***\n",
     "\n",
     "Amazon OpenSearch Serverless is a serverless option in Amazon OpenSearch Service. As a developer, you can use OpenSearch Serverless to run petabyte-scale workloads without configuring, managing, and scaling OpenSearch clusters. You get the same interactive millisecond response times as OpenSearch Service with the simplicity of a serverless environment. Pay only for what you use by automatically scaling resources to provide the right amount of capacity for your application—without impacting data ingestion. "
    ]

--- a/03_QuestionAnswering/02_qa_w_rag_claude_opensearch.ipynb
+++ b/03_QuestionAnswering/02_qa_w_rag_claude_opensearch.ipynb
@@ -340,7 +340,7 @@
    "source": [
     "Following the similar pattern embeddings could be generated for the entire corpus and stored in a vector store.\n",
     "\n",
-    "Firt of all we have to create a vector store. In this workshop we will use ***Amazon OpenSerach serverless.***\n",
+    "Firt of all we have to create a vector store. In this workshop we will use ***Amazon OpenSearch serverless.***\n",
     "\n",
     "Amazon OpenSearch Serverless is a serverless option in Amazon OpenSearch Service. As a developer, you can use OpenSearch Serverless to run petabyte-scale workloads without configuring, managing, and scaling OpenSearch clusters. You get the same interactive millisecond response times as OpenSearch Service with the simplicity of a serverless environment. Pay only for what you use by automatically scaling resources to provide the right amount of capacity for your application—without impacting data ingestion. "
    ]


### PR DESCRIPTION
*Issue #, if available:*
Correction of OpenSearch spelling.

*Description of changes:*
In the ipynb for Q&A of the Bedrock workshop, OpenSearch was wrongly spelled. Corrected the same.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
