### PR TITLE
Updated Entity Extraction Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ This repository contains notebook examples for the Bedrock Architecture Patterns
 
 ### Entity Extraction
 
-- [Entity Extraction with Claude v2](./08_EntityExtraction/entitiy_extraction.ipynb): This notebook shows how LLM can be used to extract specific information from natural text.
+- [Entity Extraction with Claude v2](./08_EntityExtraction/entity_extraction.ipynb): This notebook shows how LLM can be used to extract specific information from natural text.
 
 ### Chatbot and LLMs Guardrails
 


### PR DESCRIPTION
*Issue #, if available:*
404 when clicking [Entity Extraction with Claude v2](https://github.com/aws-samples/amazon-bedrock-workshop/blob/main/08_EntityExtraction/entitiy_extraction.ipynb): from readme

*Description of changes:*
its just a small typo that i fixed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
