### PR TITLE
Fix: cannot import `utils`, fix with boto3, bedrock client and runtime, improve docs

### DIFF
--- a/00_Intro/bedrock_boto3_setup.ipynb
+++ b/00_Intro/bedrock_boto3_setup.ipynb
@@ -30,12 +30,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "108c611c-7246-45c4-9f1e-76888b5076eb",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Defaulting to user installation because normal site-packages is not writeable\n",
+      "Collecting boto3>=1.28.57\n",
+      "  Using cached boto3-1.34.5-py3-none-any.whl (139 kB)\n",
+      "Collecting awscli>=1.29.57\n",
+      "  Using cached awscli-1.32.5-py3-none-any.whl (4.3 MB)\n",
+      "Collecting botocore>=1.31.57\n",
+      "  Using cached botocore-1.34.5-py3-none-any.whl (11.9 MB)\n",
+      "Collecting jmespath<2.0.0,>=0.7.1 (from boto3>=1.28.57)\n",
+      "  Using cached jmespath-1.0.1-py3-none-any.whl (20 kB)\n",
+      "Collecting s3transfer<0.10.0,>=0.9.0 (from boto3>=1.28.57)\n",
+      "  Using cached s3transfer-0.9.0-py3-none-any.whl (82 kB)\n",
+      "Collecting docutils<0.17,>=0.10 (from awscli>=1.29.57)\n",
+      "  Using cached docutils-0.16-py2.py3-none-any.whl (548 kB)\n",
+      "Collecting PyYAML<6.1,>=3.10 (from awscli>=1.29.57)\n",
+      "  Downloading PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl (174 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m174.4/174.4 kB\u001b[0m \u001b[31m1.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "\u001b[?25hCollecting colorama<0.4.5,>=0.2.5 (from awscli>=1.29.57)\n",
+      "  Using cached colorama-0.4.4-py2.py3-none-any.whl (16 kB)\n",
+      "Collecting rsa<4.8,>=3.1.2 (from awscli>=1.29.57)\n",
+      "  Using cached rsa-4.7.2-py3-none-any.whl (34 kB)\n",
+      "Collecting python-dateutil<3.0.0,>=2.1 (from botocore>=1.31.57)\n",
+      "  Using cached python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)\n",
+      "Collecting urllib3<1.27,>=1.25.4 (from botocore>=1.31.57)\n",
+      "  Downloading urllib3-1.26.18-py2.py3-none-any.whl (143 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m143.8/143.8 kB\u001b[0m \u001b[31m7.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hCollecting six>=1.5 (from python-dateutil<3.0.0,>=2.1->botocore>=1.31.57)\n",
+      "  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)\n",
+      "Collecting pyasn1>=0.1.3 (from rsa<4.8,>=3.1.2->awscli>=1.29.57)\n",
+      "  Using cached pyasn1-0.5.1-py2.py3-none-any.whl (84 kB)\n",
+      "Installing collected packages: urllib3, six, PyYAML, pyasn1, jmespath, docutils, colorama, rsa, python-dateutil, botocore, s3transfer, boto3, awscli\n",
+      "  Attempting uninstall: urllib3\n",
+      "    Found existing installation: urllib3 2.0.2\n",
+      "    Uninstalling urllib3-2.0.2:\n",
+      "      Successfully uninstalled urllib3-2.0.2\n",
+      "  Attempting uninstall: python-dateutil\n",
+      "    Found existing installation: python-dateutil 2.8.2\n",
+      "    Uninstalling python-dateutil-2.8.2:\n",
+      "      Successfully uninstalled python-dateutil-2.8.2\n",
+      "Successfully installed PyYAML-6.0.1 awscli-1.32.5 boto3-1.34.5 botocore-1.34.5 colorama-0.4.4 docutils-0.16 jmespath-1.0.1 pyasn1-0.5.1 python-dateutil-2.8.2 rsa-4.7.2 s3transfer-0.9.0 six-1.16.0 urllib3-1.26.18\n",
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.1.2\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.3.2\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49m/Applications/Xcode.app/Contents/Developer/usr/bin/python3 -m pip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
     "%pip install --no-build-isolation --force-reinstall \\\n",
     "    \"boto3>=1.28.57\" \\\n",
@@ -70,10 +120,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "12a834cf",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.1.2\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.3.2\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49m/Applications/Xcode.app/Contents/Developer/usr/bin/python3 -m pip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
     "%pip install --quiet \\\n",
     "    \"langchain>=0.0.350\" \\\n",
@@ -99,10 +160,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "fbe0a18f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.1.2\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.3.2\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49m/Applications/Xcode.app/Contents/Developer/usr/bin/python3 -m pip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
     "%pip install --quiet \\\n",
     "    xmltodict==0.13.0  \\\n",
@@ -110,7 +182,6 @@
     "    yfinance  \\\n",
     "    pandas_datareader  \\\n",
     "    langchain_experimental \\\n",
-    "    pysqlite3 \\\n",
     "    google-search-results\n"
    ]
   },
@@ -124,10 +195,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "4ef71a19",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.1.2\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.3.2\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49m/Applications/Xcode.app/Contents/Developer/usr/bin/python3 -m pip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
     "%pip install --quiet beautifulsoup4\n"
    ]
@@ -142,10 +224,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "7bce99bd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.1.2\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.3.2\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49m/Applications/Xcode.app/Contents/Developer/usr/bin/python3 -m pip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
     "%pip install --quiet \"pillow>=9.5,<10\"\n"
    ]
@@ -171,10 +264,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "fbf0fde6",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+      "langchain-experimental 0.0.47 requires langchain<0.1,>=0.0.350, but you have langchain 0.0.251 which is incompatible.\n",
+      "pydantic-core 2.14.5 requires typing-extensions!=4.7.0,>=4.6.0, but you have typing-extensions 4.5.0 which is incompatible.\u001b[0m\u001b[31m\n",
+      "\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.1.2\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.3.2\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49m/Applications/Xcode.app/Contents/Developer/usr/bin/python3 -m pip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n",
+      "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+      "nemoguardrails 0.5.0 requires langchain==0.0.251, but you have langchain 0.0.352 which is incompatible.\u001b[0m\u001b[31m\n",
+      "\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.1.2\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.3.2\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49m/Applications/Xcode.app/Contents/Developer/usr/bin/python3 -m pip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
     "\n",
     "%pip install -qU --no-cache-dir nemoguardrails==0.5.0\n",
@@ -196,12 +309,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "f645bbbb-43ef-460a-8e8e-7b06b3b3b102",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<script>Jupyter.notebook.kernel.restart()</script>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# restart kernel\n",
     "from IPython.core.display import HTML\n",
@@ -244,7 +371,57 @@
     "\n",
     "#### A note about `langchain`\n",
     "\n",
-    "The Bedrock classes provided by `langchain` create a Bedrock boto3 client by default. To customize your Bedrock configuration, we recommend to explicitly create the Bedrock client using the method below, and pass it to the [`langchain.Bedrock`](https://python.langchain.com/docs/integrations/llms/bedrock) class instantiation method using `client=boto3_bedrock`"
+    "The Bedrock classes provided by `langchain` create a Bedrock boto3 client by default. To customize your Bedrock configuration, we recommend to explicitly create the Bedrock client using the method below, and pass it to the [`langchain.Bedrock`](https://python.langchain.com/docs/integrations/llms/bedrock) class instantiation method using `client=boto3_bedrock`\n",
+    "\n",
+    "\n",
+    "#### Setup aws credentials\n",
+    "\n",
+    "1.  Create a new IAM user with `local code` access to Amazon Bedrock resources. \n",
+    "    *AmazonBedrockFullAccess* policy will provide all the required permissions to the user.\n",
+    "    *AmazonS3FullAccess* policy will provide access to S3 bucket.\n",
+    "\n",
+    "    [Create IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html#id_users_create_console)\n",
+    "\n",
+    "    ![IAM Image](https://raw.githubusercontent.com/Dinuda/BedrockBoto3Setup/main/images/confuser.png?raw=true)\n",
+    "\n",
+    "2. Create a new AWS profile\n",
+    "    ```bash\n",
+    "    aws configure --profile bedrockuser\n",
+    "\n",
+    "    AWS Access Key ID [None]: <access_key_id>\n",
+    "    AWS Secret Access Key [None]: <secret_access_key>\n",
+    "    Default region name [None]: <region>\n",
+    "    Default output format [None]: text\n",
+    "    ```\n",
+    "\n",
+    "3. Create new AWS service role for Bedrock\n",
+    "   \n",
+    "    [Create service role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-service.html#roles-creatingrole-service-console)\n",
+    "    \n",
+    "    ![IAM Image](https://raw.githubusercontent.com/Dinuda/BedrockBoto3Setup/main/images/servrole.png?raw=true)\n",
+    "   \n",
+    "    -- Trust Policy\n",
+    "    ```\n",
+    "    {\n",
+    "        \"Version\": \"2012-10-17\",\n",
+    "        \"Statement\": [\n",
+    "            {\n",
+    "                \"Effect\": \"Allow\",\n",
+    "                \"Principal\": {\n",
+    "                    \"AWS\": \"arn:aws:iam::<userid>:role/service-role/AgentFineTuningServiceRole\",\n",
+    "                    \"Service\": [\n",
+    "                        \"sagemaker.amazonaws.com\",\n",
+    "                        \"bedrock.amazonaws.com\",\n",
+    "                        \"events.amazonaws.com\"\n",
+    "                    ]\n",
+    "                },\n",
+    "                \"Action\": \"sts:AssumeRole\"\n",
+    "            }\n",
+    "        ]\n",
+    "    }\n",
+    "    ```\n",
+    "\n",
+    "4. Copy the `Role ARN`"
    ]
   },
   {
@@ -275,11 +452,7 @@
     "# os.environ[\"BEDROCK_ASSUME_ROLE\"] = \"<YOUR_ROLE_ARN>\"  # E.g. \"arn:aws:...\"\n",
     "\n",
     "\n",
-    "boto3_bedrock = bedrock.get_bedrock_client(\n",
-    "    assumed_role=os.environ.get(\"BEDROCK_ASSUME_ROLE\", None),\n",
-    "    region=os.environ.get(\"AWS_DEFAULT_REGION\", None),\n",
-    "    runtime=False\n",
-    ")\n"
+    "boto3_bedrock = boto3.client('bedrock')"
    ]
   },
   {
@@ -575,10 +748,7 @@
    },
    "outputs": [],
    "source": [
-    "bedrock_runtime = bedrock.get_bedrock_client(\n",
-    "    assumed_role=os.environ.get(\"BEDROCK_ASSUME_ROLE\", None),\n",
-    "    region=os.environ.get(\"AWS_DEFAULT_REGION\", None)\n",
-    ")\n"
+    "bedrock_runtime = boto3.client('bedrock-runtime')"
    ]
   },
   {
@@ -1650,9 +1820,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science 3.0)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1664,7 +1834,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/00_Intro/bedrock_boto3_setup.ipynb
+++ b/00_Intro/bedrock_boto3_setup.ipynb
@@ -442,8 +442,6 @@
     "\n",
     "module_path = \"..\"\n",
     "sys.path.append(os.path.abspath(module_path))\n",
-    "from utils import bedrock, print_ww\n",
-    "\n",
     "\n",
     "# ---- ⚠️ Un-comment and edit the below lines as needed for your AWS setup ⚠️ ----\n",
     "\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Add clear instructions on how to setup aws service role, cli user and user profile. 
2. Fix: `from utils import bedrock` - There was no library named utils, there is no pip package for bedrock utils, to make it work you need to manually copy paste files into site_packages. Ref: [Issue 31](https://github.com/aws-samples/amazon-bedrock-workshop/issues/31)
      - use 'boto3.client()` instead
3. According to instructions from [Issue 31](https://github.com/aws-samples/amazon-bedrock-workshop/issues/31), the utils do not contain `invoke_model`.
      - use `boto3.runtime()`
      -```bedrock_runtime = boto3.client('bedrock-runtime')```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
