### PR TITLE
add examples using maskPrompt to titan image generator model example notebook

### DIFF
--- a/05_Image/bedrock-titan-image-generator.ipynb
+++ b/05_Image/bedrock-titan-image-generator.ipynb
@@ -593,6 +593,88 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Apart from using \"maskImage\", we can use \"maskPrompt\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "inpaint_prompt = \"add a roller coaster\"\n",
+    "negative_prompts = \"bad quality, low res\"\n",
+    "mask_prompt = \"house\" # replace house in img1 with a roller coaster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Payload creation\n",
+    "body = json.dumps({\n",
+    "    \"taskType\": \"INPAINTING\",\n",
+    "    \"inPaintingParams\": {\n",
+    "        \"text\": inpaint_prompt,              # Optional\n",
+    "        \"negativeText\": negative_prompts,    # Optional\n",
+    "        \"image\": image_to_base64(img1),     # Required\n",
+    "        \"maskPrompt\": mask_prompt,             # One of \"maskImage\" or \"maskPrompt\" is required\n",
+    "        # \"maskImage\": image_to_base64(mask),  # Input maskImage based on the values 0 (black) or 255 (white) only\n",
+    "    },                                                 \n",
+    "    \"imageGenerationConfig\": {\n",
+    "        \"numberOfImages\": 1,\n",
+    "        \"quality\": \"premium\",\n",
+    "        \"height\": 1024,\n",
+    "        \"width\": 1024,\n",
+    "        \"cfgScale\": 7.5,\n",
+    "        \"seed\": 42\n",
+    "    }\n",
+    "})\n",
+    "\n",
+    "# Model invocation\n",
+    "response = boto3_bedrock.invoke_model(\n",
+    "    body=body,\n",
+    "    modelId=\"amazon.titan-image-generator-v1\",\n",
+    "    accept=\"application/json\", \n",
+    "    contentType=\"application/json\"\n",
+    ")\n",
+    "\n",
+    "# Output processing\n",
+    "response_body = json.loads(response.get(\"body\").read())\n",
+    "img4_b64 = response_body[\"images\"][0]\n",
+    "print(f\"Output: {img4_b64[0:80]}...\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "os.makedirs(\"data/titan\", exist_ok=True)\n",
+    "inpaint2 = Image.open(\n",
+    "    io.BytesIO(\n",
+    "        base64.decodebytes(\n",
+    "            bytes(img4_b64, \"utf-8\")\n",
+    "        )\n",
+    "    )\n",
+    ")\n",
+    "inpaint2.save(\"data/titan/inpaint2.png\")\n",
+    "inpaint2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Outpainting\n",
     "\n",
     "In this final section, we are going to *extend* the image.\n",
@@ -726,7 +808,7 @@
     "    {\n",
     "        \"taskType\": \"OUTPAINTING\",\n",
     "        \"outPaintingParams\": {\n",
-    "            \"text\": prompt,\n",
+    "            \"text\": outpaint_prompt,\n",
     "            # \"negativeText\": negative_prompts,\n",
     "            \"image\": image_to_base64(\n",
     "                ImageOps.expand(\n",
@@ -757,7 +839,7 @@
     "\n",
     "# Output processing\n",
     "response_body = json.loads(response.get(\"body\").read())\n",
-    "image_4_b64_str = response_body[\"images\"][0]\n",
+    "image_5_b64_str = response_body[\"images\"][0]\n",
     "print(f\"Output: {image_4_b64_str[0:80]}...\")"
    ]
   },
@@ -782,7 +864,7 @@
     "outpaint = Image.open(\n",
     "    io.BytesIO(\n",
     "        base64.decodebytes(\n",
-    "            bytes(image_4_b64_str, \"utf-8\")\n",
+    "            bytes(image_5_b64_str, \"utf-8\")\n",
     "        )\n",
     "    )\n",
     ")\n",
@@ -790,6 +872,102 @@
     "\n",
     "# Display\n",
     "outpaint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Apart from using \"maskImage\", we can use \"maskPrompt\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "outpaint_prompt = \"add some trees and houses near the lake\"\n",
+    "# negative_prompt = \"bad quality, low res\"\n",
+    "\n",
+    "# try different mask_prompt to see the difference in generated images\n",
+    "mask_prompt = \"lake\"\n",
+    "# mask_prompt = \"forest\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Payload creation\n",
+    "body = json.dumps(\n",
+    "    {\n",
+    "        \"taskType\": \"OUTPAINTING\",\n",
+    "        \"outPaintingParams\": {\n",
+    "            \"text\": outpaint_prompt,\n",
+    "            # \"negativeText\": negative_prompts,\n",
+    "            \"image\": image_to_base64(\n",
+    "                ImageOps.expand(\n",
+    "                    inpaint_crop,\n",
+    "                    border=border,\n",
+    "                    fill='white'\n",
+    "                )),\n",
+    "            # \"image\": image_to_base64(inpaint_crop),\n",
+    "            \"maskPrompt\": mask_prompt,\n",
+    "            # \"maskImage\": image_to_base64(mask),\n",
+    "            \"outPaintingMode\": \"DEFAULT\"\n",
+    "        },\n",
+    "        \"imageGenerationConfig\": {\n",
+    "            \"numberOfImages\": 1,\n",
+    "            \"quality\": \"standard\",\n",
+    "            \"cfgScale\": 1.5,\n",
+    "            \"seed\": 321,\n",
+    "        }\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "# Model invocation\n",
+    "response = boto3_bedrock.invoke_model(\n",
+    "    body = body, \n",
+    "    modelId = \"amazon.titan-image-generator-v1\",\n",
+    "    accept = \"application/json\", \n",
+    "    contentType = \"application/json\"\n",
+    ")\n",
+    "\n",
+    "# Output processing\n",
+    "response_body = json.loads(response.get(\"body\").read())\n",
+    "image_6_b64_str = response_body[\"images\"][0]\n",
+    "print(f\"Output: {image_6_b64_str[0:80]}...\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "os.makedirs(\"data\", exist_ok=True)\n",
+    "\n",
+    "# Decode + save\n",
+    "outpaint2 = Image.open(\n",
+    "    io.BytesIO(\n",
+    "        base64.decodebytes(\n",
+    "            bytes(image_6_b64_str, \"utf-8\")\n",
+    "        )\n",
+    "    )\n",
+    ")\n",
+    "outpaint2.save(\"data/titan/outpaint2.png\")\n",
+    "\n",
+    "# Display\n",
+    "outpaint2"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. For inpaint, added code using "maskPrompt"
2. For outpaint, added code using "maskPrompt"
3. In the current notebook https://github.com/aws-samples/amazon-bedrock-workshop/blob/main/05_Image/bedrock-titan-image-generator.ipynb, "outpaint_prompt" was defined, but never used. I updated the code to use "outpaint_prompt". I think the author made a mistake here.
4. Changed image_4_b64_str to image_5_b64_str, since a new image was generated in my newly added code, and image 4 was used in my new code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
