### PR TITLE
Update bedrock-titan-image-generator.ipynb

### DIFF
--- a/05_Image/bedrock-titan-image-generator.ipynb
+++ b/05_Image/bedrock-titan-image-generator.ipynb
@@ -839,8 +839,8 @@
     "\n",
     "# Output processing\n",
     "response_body = json.loads(response.get(\"body\").read())\n",
-    "image_4_b64_str = response_body[\"images\"][0]\n",
-    "print(f\"Output: {image_4_b64_str[0:80]}...\")"
+    "img_5_b64_str = response_body[\"images\"][0]\n",
+    "print(f\"Output: {img_5_b64_str[0:80]}...\")"
    ]
   },
   {
@@ -942,8 +942,8 @@
     "\n",
     "# Output processing\n",
     "response_body = json.loads(response.get(\"body\").read())\n",
-    "image_6_b64_str = response_body[\"images\"][0]\n",
-    "print(f\"Output: {image_6_b64_str[0:80]}...\")"
+    "img_6_b64_str = response_body[\"images\"][0]\n",
+    "print(f\"Output: {img_6_b64_str[0:80]}...\")"
    ]
   },
   {
@@ -960,7 +960,7 @@
     "outpaint2 = Image.open(\n",
     "    io.BytesIO(\n",
     "        base64.decodebytes(\n",
-    "            bytes(image_6_b64_str, \"utf-8\")\n",
+    "            bytes(img_6_b64_str, \"utf-8\")\n",
     "        )\n",
     "    )\n",
     ")\n",

--- a/05_Image/bedrock-titan-image-generator.ipynb
+++ b/05_Image/bedrock-titan-image-generator.ipynb
@@ -717,10 +717,10 @@
     "        Image.new(\n",
     "            mode = \"RGB\",\n",
     "            size = img.size,\n",
-    "            color = 'white'\n",
+    "            color = 'black'\n",
     "        ),\n",
     "        border=border,\n",
-    "        fill='black'\n",
+    "        fill='white'\n",
     "    )"
    ]
   },
@@ -839,7 +839,7 @@
     "\n",
     "# Output processing\n",
     "response_body = json.loads(response.get(\"body\").read())\n",
-    "image_5_b64_str = response_body[\"images\"][0]\n",
+    "image_4_b64_str = response_body[\"images\"][0]\n",
     "print(f\"Output: {image_4_b64_str[0:80]}...\")"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:*
- Bug of Outpainting mask creating: swapped black and white
- Variable name typos

*Description of changes:*
- swapped black&white in outpainting mask
- fix naming typos


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
