### PR TITLE
Added installation of anthropic since it is used by langchain functio…

### DIFF
--- a/00_Intro/bedrock_boto3_setup.ipynb
+++ b/00_Intro/bedrock_boto3_setup.ipynb
@@ -85,7 +85,8 @@
     "    apache-beam==2.52. \\\n",
     "    tiktoken==0.5.2 \\\n",
     "    \"ipywidgets>=7,<8\" \\\n",
-    "    matplotlib==3.8.2\n"
+    "    matplotlib==3.8.2 \\\n",
+    "    anthropic==0.9.0\n"
    ]
   },
   {


### PR DESCRIPTION
…n get_num_tokens() for token counting when using anthropic models with bedrock

*Issue #, if available:*
An issue occurred when executing a cell in [02_contextual_generation.ipynb](https://github.com/aws-samples/amazon-bedrock-workshop/blob/main/01_Generation/02_contextual_generation.ipynb)

The following cell indicated the anthropic library missing. This only happens when a Anthropic model is used with Bedrock. This refers to the [anthropic](https://pypi.org/project/anthropic/) library not being installed on the machine the notebook is used on. The library is used by langchain for token counting.

num_tokens = textgen_llm.get_num_tokens(prompt)
print(f”Our prompt has {num_tokens} tokens”)

Error: 
ModuleNotFoundError                       Traceback (most recent call last)
File /opt/conda/lib/python3.10/site-packages/langchain_community/utilities/anthropic.py:6, in _get_anthropic_client()
      5 try:
----> 6     import anthropic
      7 except ImportError:

ModuleNotFoundError: No module named 'anthropic'

*Description of changes:*
Added the installation of the anthropic library to the set-up notebook in 00-intro


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
