### PR TITLE
Fixed issues in the outpainting with titan

### DIFF
--- a/05_Image/bedrock-titan-image-generator.ipynb
+++ b/05_Image/bedrock-titan-image-generator.ipynb
@@ -717,10 +717,10 @@
     "        Image.new(\n",
     "            mode = \"RGB\",\n",
     "            size = img.size,\n",
-    "            color = 'white'\n",
+    "            color = 'black'\n",
     "        ),\n",
     "        border=border,\n",
-    "        fill='black'\n",
+    "        fill='white'\n",
     "    )"
    ]
   },

--- a/05_Image/bedrock-titan-image-generator.ipynb
+++ b/05_Image/bedrock-titan-image-generator.ipynb
@@ -840,7 +840,7 @@
     "# Output processing\n",
     "response_body = json.loads(response.get(\"body\").read())\n",
     "image_5_b64_str = response_body[\"images\"][0]\n",
-    "print(f\"Output: {image_4_b64_str[0:80]}...\")"
+    "print(f\"Output: {image_5_b64_str[0:80]}...\")"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*
1- 'image_4_b64_str' variable does not exist, 'image_5_b64_str' should be used instead
2- 'black' and 'white' are inverted in the outpainting mask. As a result, the image created by titan is wrong

*Description of changes:*
1- use 'image_5_b64_str' instead of 'image_4_b64_str'
2- swap 'black' and 'white' 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
