### PR TITLE
Add Pillow package

### DIFF
--- a/00_Prerequisites/bedrock_basics.ipynb
+++ b/00_Prerequisites/bedrock_basics.ipynb
@@ -525,6 +525,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install pillow\n",
     "import base64\n",
     "import io\n",
     "from PIL import Image\n",


### PR DESCRIPTION
Pillow package was missing.
Added pip install instruction for this

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
