### PR TITLE
Added headers to get_lat_long functions and included missing libraries

### DIFF
--- a/06_OpenSource_examples/05_OpenSource_agents/00_agent_based_text_generation.ipynb
+++ b/06_OpenSource_examples/05_OpenSource_agents/00_agent_based_text_generation.ipynb
@@ -22,6 +22,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "271b6a0f",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Install dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5e3abc3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install xmltodict --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "4c7cced6",
    "metadata": {},
    "source": [
@@ -31,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "85063bca",
    "metadata": {},
    "outputs": [],
@@ -74,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "e8bb0dd6",
    "metadata": {},
    "outputs": [],
@@ -89,7 +108,8 @@
     "def get_lat_long(place: str):\n",
     "    url = \"https://nominatim.openstreetmap.org/search\"\n",
     "    params = {'q': place, 'format': 'json', 'limit': 1}\n",
-    "    response = requests.get(url, params=params).json()\n",
+    "    headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}\n",
+    "    response = requests.get(url, params=params,headers=headers).json()\n",
     "    if response:\n",
     "        lat = response[0][\"lat\"]\n",
     "        lon = response[0][\"lon\"]\n",
@@ -176,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "6edc9104",
    "metadata": {},
    "outputs": [],
@@ -245,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "59df5a7e",
    "metadata": {},
    "outputs": [],
@@ -999,7 +1019,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/06_OpenSource_examples/05_OpenSource_agents/01_tools_agents.ipynb
+++ b/06_OpenSource_examples/05_OpenSource_agents/01_tools_agents.ipynb
@@ -62,10 +62,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#!pip install langchain==0.1.17\n",
-    "#!pip install langchain-anthropic\n",
-    "#!pip install boto3==1.34.95\n",
-    "#!pip install faiss-cpu==1.8.0"
+    "!pip install langchain==0.1.17\n",
+    "!pip install langchain-anthropic\n",
+    "!pip install boto3==1.34.95\n",
+    "!pip install faiss-cpu==1.8.0"
    ]
   },
   {
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "19cb8580",
    "metadata": {},
    "outputs": [],
@@ -291,7 +291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "2b8a161b",
    "metadata": {},
    "outputs": [],
@@ -507,7 +507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "73fdb2be",
    "metadata": {},
    "outputs": [],
@@ -540,7 +540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "f64328fd",
    "metadata": {},
    "outputs": [],
@@ -559,8 +559,9 @@
     "    \"\"\"Returns the latitude and longitude for a given place name as a dict object of python.\"\"\"\n",
     "    url = \"https://nominatim.openstreetmap.org/search\"\n",
     "\n",
+    "    headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}\n",
     "    params = {'q': place, 'format': 'json', 'limit': 1}\n",
-    "    response = requests.get(url, params=params).json()\n",
+    "    response = requests.get(url, params=params,headers=headers).json()\n",
     "\n",
     "    if response:\n",
     "        lat = response[0][\"lat\"]\n",
@@ -660,7 +661,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "445b9ade",
    "metadata": {},
    "outputs": [],
@@ -849,7 +850,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "90b576b1",
    "metadata": {},
    "outputs": [],
@@ -1135,8 +1136,9 @@
     "    \"\"\"Returns the latitude and longitude for a given place name as a dict object of python.\"\"\"\n",
     "    url = \"https://nominatim.openstreetmap.org/search\"\n",
     "\n",
+    "    headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}\n",
     "    params = {'q': place, 'format': 'json', 'limit': 1}\n",
-    "    response = requests.get(url, params=params).json()\n",
+    "    response = requests.get(url, params=params, headers=headers).json()\n",
     "\n",
     "    if response:\n",
     "        lat = response[0][\"lat\"]\n",
@@ -1178,7 +1180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "6939ffb6",
    "metadata": {},
    "outputs": [],
@@ -1266,7 +1268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "b40bc910",
    "metadata": {},
    "outputs": [],
@@ -1913,7 +1915,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/06_OpenSource_examples/05_OpenSource_agents/02_tools_retriever_agents.ipynb
+++ b/06_OpenSource_examples/05_OpenSource_agents/02_tools_retriever_agents.ipynb
@@ -65,7 +65,8 @@
     "#!pip install langchain==0.1.17\n",
     "#!pip install langchain-anthropic\n",
     "#!pip install boto3==1.34.95\n",
-    "#!pip install faiss-cpu==1.8.0"
+    "#!pip install faiss-cpu==1.8.0\n",
+    "#!pip install pypdf"
    ]
   },
   {
@@ -109,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "19cb8580",
    "metadata": {},
    "outputs": [],
@@ -291,7 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "2b8a161b",
    "metadata": {},
    "outputs": [],
@@ -407,7 +408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "73fdb2be",
    "metadata": {},
    "outputs": [],
@@ -440,7 +441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "f64328fd",
    "metadata": {},
    "outputs": [],
@@ -459,8 +460,9 @@
     "    \"\"\"Returns the latitude and longitude for a given place name as a dict object of python.\"\"\"\n",
     "    url = \"https://nominatim.openstreetmap.org/search\"\n",
     "\n",
+    "    headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}\n",
     "    params = {'q': place, 'format': 'json', 'limit': 1}\n",
-    "    response = requests.get(url, params=params).json()\n",
+    "    response = requests.get(url, params=params, headers=headers).json()\n",
     "\n",
     "    if response:\n",
     "        lat = response[0][\"lat\"]\n",
@@ -482,7 +484,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "445b9ade",
    "metadata": {},
    "outputs": [],
@@ -681,8 +683,9 @@
     "    \"\"\"Returns the latitude and longitude for a given place name as a dict object of python.\"\"\"\n",
     "    url = \"https://nominatim.openstreetmap.org/search\"\n",
     "\n",
+    "    headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}\n",
     "    params = {'q': place, 'format': 'json', 'limit': 1}\n",
-    "    response = requests.get(url, params=params).json()\n",
+    "    response = requests.get(url, params=params,headers=headers).json()\n",
     "\n",
     "    if response:\n",
     "        lat = response[0][\"lat\"]\n",
@@ -791,7 +794,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "0e97585d",
    "metadata": {},
    "outputs": [],
@@ -923,7 +926,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "b40bc910",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION

*Issue #, if available:*
This PR solves issue 252 as a byproduct (https://github.com/aws-samples/amazon-bedrock-workshop/issues/252)

*Description of changes:*
1- Added hardocded headers in every instance of `get_lat_long` function to avoid blocking from nominatim.
2- Added pip install for `xmltodict` in `00_agent_based_text_generation` as it was missing and library is used
3- Added pip install for `pypdf` in `02_tools_retriever_agent` as it was missing and library is used

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
