### PR TITLE
The generated code now is printed without truncation in the output

### DIFF
--- a/01_Text_generation/01_code_generation_w_bedrock.ipynb
+++ b/01_Text_generation/01_code_generation_w_bedrock.ipynb
@@ -231,6 +231,7 @@
    },
    "outputs": [],
    "source": [
+    "from IPython.display import clear_output, display, display_markdown, Markdown\n",
     "modelId = 'anthropic.claude-v2' # change this to use a different version from the model provider\n",
     "accept = 'application/json'\n",
     "contentType = 'application/json'\n",
@@ -238,7 +239,8 @@
     "response = boto3_bedrock.invoke_model(body=body, modelId=modelId, accept=accept, contentType=contentType)\n",
     "response_body = json.loads(response.get('body').read())\n",
     "\n",
-    "response_body.get('completion')"
+    "response_body.get('completion')\n",
+    "display_markdown(Markdown(print(response_body.get('completion'), end='')))"
    ]
   },
   {

--- a/01_Text_generation/01_code_generation_w_bedrock.ipynb
+++ b/01_Text_generation/01_code_generation_w_bedrock.ipynb
@@ -239,7 +239,6 @@
     "response = boto3_bedrock.invoke_model(body=body, modelId=modelId, accept=accept, contentType=contentType)\n",
     "response_body = json.loads(response.get('body').read())\n",
     "\n",
-    "response_body.get('completion')\n",
     "display_markdown(Markdown(print(response_body.get('completion'), end='')))"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:* The existing code asked user to copy the output to a text editor to view it as it was trunctaed in the cell output of the notebook

*Description of changes:*
Added the display_markdown() from IPython.display so that the output is displayed in the cell output and user does not have to copy the output. In the workshops this is usually a question from the participants. Hence making the change

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
