### PR TITLE
04_entity_extraction: Replace deprecated langchain API

### DIFF
--- a/01_Text_generation/04_entity_extraction.ipynb
+++ b/01_Text_generation/04_entity_extraction.ipynb
@@ -37,7 +37,8 @@
    },
    "outputs": [],
    "source": [
-    "%pip install langchain==0.1.11"
+    "%pip install langchain-aws\n",
+    "%pip install bs4"
    ]
   },
   {
@@ -56,7 +57,7 @@
     "import boto3\n",
     "import botocore\n",
     "\n",
-    "boto3_bedrock = boto3.client('bedrock-runtime')"
+    "boto3_bedrock = boto3.client(\"bedrock-runtime\")"
    ]
   },
   {
@@ -84,18 +85,19 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.llms.bedrock import Bedrock\n",
+    "from langchain_aws import BedrockLLM\n",
     "\n",
-    "# - create the Anthropic Model\n",
-    "llm = Bedrock(\n",
+    "llm = BedrockLLM(\n",
     "    model_id=\"anthropic.claude-v2\",\n",
     "    client=boto3_bedrock,\n",
     "    model_kwargs={\n",
     "        \"max_tokens_to_sample\": 200,\n",
-    "        \"temperature\": 0, # Using 0 to get reproducible results\n",
-    "        \"stop_sequences\": [\"\\n\\nHuman:\"]\n",
-    "    }\n",
-    ")"
+    "        \"temperature\": 0,  # Using 0 to get reproducible results\n",
+    "        \"stop_sequences\": [\"\\n\\nHuman:\"],\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "print(f\"llm:\\n{llm}\")"
    ]
   },
   {
@@ -171,7 +173,7 @@
    },
    "outputs": [],
    "source": [
-    "result = llm(query)\n",
+    "result = llm.invoke(input=query)\n",
     "print(result.strip())"
    ]
   },
@@ -223,7 +225,7 @@
    "outputs": [],
    "source": [
     "query = prompt.format(email=book_question_email)\n",
-    "result = llm(query)\n",
+    "result = llm.invoke(input=query)\n",
     "print(result.strip())"
    ]
   },
@@ -246,12 +248,13 @@
    "source": [
     "from bs4 import BeautifulSoup\n",
     "\n",
+    "\n",
     "def extract_by_tag(response: str, tag: str, extract_all=False) -> str | list[str] | None:\n",
     "    soup = BeautifulSoup(response)\n",
     "    results = soup.find_all(tag)\n",
     "    if not results:\n",
     "        return\n",
-    "        \n",
+    "\n",
     "    texts = [res.get_text() for res in results]\n",
     "    if extract_all:\n",
     "        return texts\n",
@@ -303,7 +306,7 @@
    "outputs": [],
    "source": [
     "query = prompt.format(email=return_email)\n",
-    "result = llm(query)\n",
+    "result = llm.invoke(input=query)\n",
     "print(result.strip())"
    ]
   },
@@ -359,7 +362,7 @@
    "outputs": [],
    "source": [
     "query = prompt.format(email=book_question_email)\n",
-    "result = llm(query)\n",
+    "result = llm.invoke(input=query)\n",
     "print(result.strip())"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:* The existing API 'from langchain.llms.bedrock import Bedrock' is deprecated. 

*Description of changes:* The existing API 'from langchain.llms.bedrock import Bedrock' is deprecated. The new alternative is 'from langchain_aws import BedrockLLM'. More information: https://python.langchain.com/v0.2/docs/integrations/llms/bedrock/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
