### PR TITLE
02_Langchain-rag-retrieve-api-mistral-and-claude-v2: Replace deprecated langchain APIs

### DIFF
--- a/02_KnowledgeBases_and_RAG/2_Langchain-rag-retrieve-api-mistral-and-claude-v2.ipynb
+++ b/02_KnowledgeBases_and_RAG/2_Langchain-rag-retrieve-api-mistral-and-claude-v2.ipynb
@@ -77,7 +77,8 @@
     "%pip install --upgrade pip\n",
     "%pip install boto3==1.34.55 --force-reinstall --quiet\n",
     "%pip install botocore==1.34.55 --force-reinstall --quiet\n",
-    "%pip install langchain==0.1.10 --force-reinstall --quiet"
+    "%pip install langchain==0.1.10 --force-reinstall --quiet\n",
+    "%pip install langchain_community --force-reinstall --quiet"
    ]
   },
   {
@@ -190,7 +191,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we will call the `retreive API`, and pass `knowledge base id`, `number of results` and `query` as paramters. \n",
+    "Next, we will call the `retreive API`, and pass `knowledge base id`, `number of results` and `query` as parameters. \n",
     "\n",
     "`score`: You can view the associated score of each of the text chunk that was returned which depicts its correlation to the query in terms of how closely it matches it."
    ]
@@ -295,7 +296,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# payload with model paramters\n",
+    "# payload with model parameters\n",
     "mistral_payload = json.dumps({\n",
     "    \"prompt\": prompt,\n",
     "    \"max_tokens\":512,\n",
@@ -344,8 +345,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.llms.bedrock import Bedrock\n",
-    "from langchain.retrievers.bedrock import AmazonKnowledgeBasesRetriever\n",
+    "from langchain_aws import BedrockLLM\n",
+    "from langchain_community.retrievers import AmazonKnowledgeBasesRetriever\n",
     "\n",
     "model_kwargs_claude = {\n",
     "    \"temperature\": 0,\n",
@@ -353,9 +354,13 @@
     "    \"max_tokens_to_sample\": 3000\n",
     "}\n",
     "\n",
-    "llm = Bedrock(model_id=\"anthropic.claude-v2:1\",\n",
-    "              model_kwargs=model_kwargs_claude,\n",
-    "              client = bedrock_client,)"
+    "llm = BedrockLLM(\n",
+    "    model_id=\"anthropic.claude-v2\",\n",
+    "    client=bedrock_client,\n",
+    "    model_kwargs=model_kwargs_claude,\n",
+    ")\n",
+    "\n",
+    "print(llm)"
    ]
   },
   {
@@ -373,19 +378,16 @@
    "source": [
     "query = \"By what percentage did AWS revenue grow year-over-year in 2022?\"\n",
     "retriever = AmazonKnowledgeBasesRetriever(\n",
-    "        knowledge_base_id=kb_id,\n",
-    "        retrieval_config={\"vectorSearchConfiguration\": \n",
-    "                          {\"numberOfResults\": 4,\n",
-    "                           'overrideSearchType': \"SEMANTIC\", # optional\n",
-    "                           }\n",
-    "                          },\n",
-    "        # endpoint_url=endpoint_url,\n",
-    "        # region_name=region,\n",
-    "        # credentials_profile_name=\"<profile_name>\",\n",
-    "    )\n",
-    "docs = retriever.get_relevant_documents(\n",
-    "        query=query\n",
-    "    )\n",
+    "    knowledge_base_id=kb_id,\n",
+    "    retrieval_config={\n",
+    "        \"vectorSearchConfiguration\": {\n",
+    "            \"numberOfResults\": 4,\n",
+    "            \"overrideSearchType\": \"SEMANTIC\",  # optional\n",
+    "        }\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "docs = retriever.invoke(query)\n",
     "pp.pprint(docs)"
    ]
   },


### PR DESCRIPTION
The existing APIs 'from langchain.llms.bedrock import Bedrock' and 'from langchain.retrievers.bedrock import AmazonKnowledgeBasesRetriever'  are deprecated.

Description of changes: The existing APIs 'from langchain.llms.bedrock import Bedrock' and 'from langchain.retrievers.bedrock import AmazonKnowledgeBasesRetriever'  are deprecated. The new alternatives are 'from langchain_aws import BedrockLLM' and from langchain_community.retrievers import AmazonKnowledgeBasesRetriever. More information: https://python.langchain.com/v0.2/docs/integrations/llms/bedrock/ and https://python.langchain.com/v0.2/docs/integrations/retrievers/bedrock/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
