### PR TITLE
Improve AWS service initialization syntax in example notebooks

### DIFF
--- a/00_Prerequisites/Getting_started_with_Converse_API.ipynb
+++ b/00_Prerequisites/Getting_started_with_Converse_API.ipynb
@@ -32,27 +32,13 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's define the region and models to use. We can also setup our boto3 client."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "boto3_session = boto3.session.Session()\n",
-    "region = boto3_session.region_name\n",
-    "\n",
-    "print('Using region: ', region)\n",
-    "\n",
-    "bedrock = boto3.client(\n",
-    "    service_name = 'bedrock-runtime',\n",
-    "    region_name = region,\n",
-    "    )\n",
+    "boto3_session = boto3.session.Session() # Initialize a boto3 session (use the profile_name parameter to switch profiles if needed)\n",
+    "bedrock_runtime = boto3_session.client(service_name = 'bedrock-runtime') # Region is automatically inferred from the session\n",
     "\n",
     "MODEL_IDS = [\n",
     "    \"amazon.titan-tg1-large\",\n",
@@ -136,7 +122,7 @@
     "print(f'Prompt: {prompt}\\n')\n",
     "\n",
     "for i in MODEL_IDS:\n",
-    "    response = invoke_bedrock_model(bedrock, i, prompt)\n",
+    "    response = invoke_bedrock_model(bedrock_runtime, i, prompt)\n",
     "    print(f'Model: {i}\\n{response}')"
    ]
   },
@@ -209,7 +195,7 @@
     "\n",
     "for i in MODEL_IDS:\n",
     "    print(f'\\n\\nModel: {i}')\n",
-    "    invoke_bedrock_model_stream(bedrock, i, prompt)"
+    "    invoke_bedrock_model_stream(bedrock_runtime, i, prompt)"
    ]
   },
   {
@@ -236,7 +222,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/00_Prerequisites/bedrock_basics.ipynb
+++ b/00_Prerequisites/bedrock_basics.ipynb
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "ae2b2a05-78a9-40ca-9b5e-121030f9ede1",
    "metadata": {
     "tags": []
@@ -80,7 +80,8 @@
     "\n",
     "import boto3\n",
     "\n",
-    "boto3_bedrock = boto3.client('bedrock')"
+    "boto3_session = boto3.Session() # Initialize a boto3 session (use the profile_name parameter to switch profiles if needed)\n",
+    "bedrock_client = boto3_session.client('bedrock') # Region is automatically inferred from the session"
    ]
   },
   {
@@ -95,85 +96,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "f67b4466-12ff-4975-9811-7a19c6206604",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['amazon.titan-tg1-large',\n",
-       " 'amazon.titan-image-generator-v1:0',\n",
-       " 'amazon.titan-image-generator-v1',\n",
-       " 'amazon.titan-text-premier-v1:0',\n",
-       " 'amazon.titan-embed-g1-text-02',\n",
-       " 'amazon.titan-text-lite-v1:0:4k',\n",
-       " 'amazon.titan-text-lite-v1',\n",
-       " 'amazon.titan-text-express-v1:0:8k',\n",
-       " 'amazon.titan-text-express-v1',\n",
-       " 'amazon.titan-embed-text-v1:2:8k',\n",
-       " 'amazon.titan-embed-text-v1',\n",
-       " 'amazon.titan-embed-text-v2:0:8k',\n",
-       " 'amazon.titan-embed-text-v2:0',\n",
-       " 'amazon.titan-embed-image-v1:0',\n",
-       " 'amazon.titan-embed-image-v1',\n",
-       " 'stability.stable-diffusion-xl-v1:0',\n",
-       " 'stability.stable-diffusion-xl-v1',\n",
-       " 'ai21.j2-grande-instruct',\n",
-       " 'ai21.j2-jumbo-instruct',\n",
-       " 'ai21.j2-mid',\n",
-       " 'ai21.j2-mid-v1',\n",
-       " 'ai21.j2-ultra',\n",
-       " 'ai21.j2-ultra-v1:0:8k',\n",
-       " 'ai21.j2-ultra-v1',\n",
-       " 'anthropic.claude-instant-v1:2:100k',\n",
-       " 'anthropic.claude-instant-v1',\n",
-       " 'anthropic.claude-v2:0:18k',\n",
-       " 'anthropic.claude-v2:0:100k',\n",
-       " 'anthropic.claude-v2:1:18k',\n",
-       " 'anthropic.claude-v2:1:200k',\n",
-       " 'anthropic.claude-v2:1',\n",
-       " 'anthropic.claude-v2',\n",
-       " 'anthropic.claude-3-sonnet-20240229-v1:0:28k',\n",
-       " 'anthropic.claude-3-sonnet-20240229-v1:0:200k',\n",
-       " 'anthropic.claude-3-sonnet-20240229-v1:0',\n",
-       " 'anthropic.claude-3-haiku-20240307-v1:0:48k',\n",
-       " 'anthropic.claude-3-haiku-20240307-v1:0:200k',\n",
-       " 'anthropic.claude-3-haiku-20240307-v1:0',\n",
-       " 'cohere.command-text-v14:7:4k',\n",
-       " 'cohere.command-text-v14',\n",
-       " 'cohere.command-r-v1:0',\n",
-       " 'cohere.command-r-plus-v1:0',\n",
-       " 'cohere.command-light-text-v14:7:4k',\n",
-       " 'cohere.command-light-text-v14',\n",
-       " 'cohere.embed-english-v3:0:512',\n",
-       " 'cohere.embed-english-v3',\n",
-       " 'cohere.embed-multilingual-v3:0:512',\n",
-       " 'cohere.embed-multilingual-v3',\n",
-       " 'meta.llama2-13b-chat-v1:0:4k',\n",
-       " 'meta.llama2-13b-chat-v1',\n",
-       " 'meta.llama2-70b-chat-v1:0:4k',\n",
-       " 'meta.llama2-70b-chat-v1',\n",
-       " 'meta.llama2-13b-v1:0:4k',\n",
-       " 'meta.llama2-13b-v1',\n",
-       " 'meta.llama2-70b-v1:0:4k',\n",
-       " 'meta.llama2-70b-v1',\n",
-       " 'meta.llama3-8b-instruct-v1:0',\n",
-       " 'meta.llama3-70b-instruct-v1:0',\n",
-       " 'mistral.mistral-7b-instruct-v0:2',\n",
-       " 'mistral.mixtral-8x7b-instruct-v0:1',\n",
-       " 'mistral.mistral-large-2402-v1:0']"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "[models['modelId'] for models in boto3_bedrock.list_foundation_models()['modelSummaries']]\n"
+    "[models['modelId'] for models in bedrock_client.list_foundation_models()['modelSummaries']]\n"
    ]
   },
   {
@@ -376,6 +306,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "f48f7410",
+   "metadata": {},
+   "source": [
+    "Let's start by installing or updating boto3. You just need to run this cell the first time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "f4b2e296",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip3 install -qU boto3"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "6a0a79b9",
@@ -388,7 +336,7 @@
     "import botocore\n",
     "import json \n",
     "\n",
-    "bedrock_runtime = boto3.client('bedrock-runtime')\n"
+    "bedrock_runtime = boto3_session.client('bedrock-runtime')  # Region is automatically inferred from the session"
    ]
   },
   {
@@ -877,14 +825,6 @@
     "\n",
     "In this notebook we showed some basic examples of invoking Amazon Bedrock models using the AWS Python SDK. You're now ready to explore the other labs to dive deeper on different use-cases and patterns."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f8bb76df-4e99-4ebe-a954-53992ad317dc",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -1495,9 +1435,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science 3.0)",
+   "display_name": "base",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-310-v1"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1509,7 +1449,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
**Description:**

This PR proposes an improvement to the way AWS services are initialized in the example notebooks. Currently, the syntax used is:

```python
import boto3

boto3_bedrock = boto3.client('bedrock')
```

The improved syntax initializes a boto3 session, which allows for more flexibility, such as automatically inferring the region, switching profiles if needed:
```python
import boto3

boto3_session = boto3.Session()  # Initialize a boto3 session (use the profile_name parameter to switch profiles if needed)
bedrock_client = boto3_session.client('bedrock') # Region is automatically inferred from the session
```

**Changes Made:**

Updated the initialization syntax in a couple of example notebooks to demonstrate the improvement.

**Benefits:**
- No need to manually configure the region when initializing the client; it is automatically inferred from the session.
- Allows users to easily switch profiles by specifying the `profile_name` parameter, which is useful when running the examples locally.
- Provides a more flexible and scalable way to manage AWS service clients.

Please review these changes and let me know if you'd like me to apply this improvement to the remaining example notebooks as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
