### PR TITLE
fixed GraphState to use the messages channel

### DIFF
--- a/06_OpenSource_examples/02_Langchain_Chatbot_examples/00_medibot_3V_agents.ipynb
+++ b/06_OpenSource_examples/02_Langchain_Chatbot_examples/00_medibot_3V_agents.ipynb
@@ -1,8 +1,35 @@
 {
  "cells": [
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "b03d63b2-54c6-4862-b41b-e7c962ae506d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install boto3\n",
+    "%pip install botocore\n",
+    "%pip install langchain\n",
+    "%pip install langchain-aws\n",
+    "%pip install python-dotenv\n",
+    "%pip install dateparser\n",
+    "%pip install langgraph\n",
+    "%pip install langchain-community\n",
+    "%pip install faiss-gpu\n",
+    "%pip install grandalf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6282e31b964b236",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:31:22.040436Z",
+     "start_time": "2024-10-22T21:31:21.982034Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "import warnings\n",
     "import boto3\n",
@@ -21,22 +48,19 @@
     "        'mode': 'standard'\n",
     "    }\n",
     ")"
-   ],
-   "id": "a6282e31b964b236",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "source": "",
-   "id": "92a5cc44b316a9a0",
+   "execution_count": null,
+   "id": "260e14f1f5ac31c4",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:31:24.038183Z",
+     "start_time": "2024-10-22T21:31:23.938058Z"
+    }
+   },
    "outputs": [],
-   "execution_count": null
-  },
-  {
-   "metadata": {},
-   "cell_type": "code",
    "source": [
     "aws_access_key_id = os.getenv(\"AWS_ACCESS_KEY\")\n",
     "aws_secret_access_key = os.getenv(\"AWS_ACCESS_SECRET\")\n",
@@ -46,30 +70,39 @@
     "                      aws_secret_access_key=aws_secret_access_key,\n",
     "                    config=my_config\n",
     "                      )"
-   ],
-   "id": "260e14f1f5ac31c4",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "bc29b5745d95a07e",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:31:24.717011Z",
+     "start_time": "2024-10-22T21:31:24.683032Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "from langchain_aws import ChatBedrock\n",
-    "# from langchain_community.chat_models import BedrockChaat\n",
     "from langchain_core.messages import HumanMessage, SystemMessage\n",
     "\n",
-    "llm = ChatBedrock(client=boto3_bedrock, #credentials_profile_name='~/.aws/credentials',\n",
+    "llm = ChatBedrock(client=boto3_bedrock, \n",
     "                  model_id=\"anthropic.claude-3-haiku-20240307-v1:0\",\n",
     "                  model_kwargs=dict(temperature=0))"
-   ],
-   "id": "bc29b5745d95a07e",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "c09e231aa3edf50f",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:31:28.701636Z",
+     "start_time": "2024-10-22T21:31:25.068364Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "messages = [\n",
     "    HumanMessage(\n",
@@ -78,14 +111,12 @@
     "]\n",
     "ai_msg = llm.invoke(messages)\n",
     "ai_msg"
-   ],
-   "id": "c09e231aa3edf50f",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "7d730629ec3d2528",
+   "metadata": {},
    "source": [
     "## Naive inferencing: The root challenge in creating Chatbots and Virtual Assistants and the Agentic solution:\n",
     "\n",
@@ -94,12 +125,12 @@
     "One persistent bottleneck however is the inability of LLMs to assess whether data extracted and or its response, based on said data, is accurate and fully encapsulates a user requests (hallucinating). A way to mitigate this risk brought up by naive, inferencing with RAG is through the use of Agents. Agents are defined as a workflow that uses data, tools, and its own inferences to check that the response provided is accurate and meets users goals.\n",
     "\n",
     "![Amazon Bedrock - Agents Interface](./images/agents.jpg)"
-   ],
-   "id": "7d730629ec3d2528"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "66929125b85703cc",
+   "metadata": {},
    "source": [
     "### Key Elements of Agents\n",
     " \n",
@@ -110,12 +141,12 @@
     "\n",
     "\n",
     " Let's build an agentic workflow from scratch to see how it works, for this use case we will use Calude 3 Sonnet to power our agentic workflow."
-   ],
-   "id": "66929125b85703cc"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "ebed423080bc7eb4",
+   "metadata": {},
    "source": [
     "### Architecture [Retriever with LangGraph]\n",
     "\n",
@@ -126,18 +157,27 @@
     "1. We defined a supervisor agent responsible for deciding the steps needed to fulfill the users request, this can take the shape of using tools or data retrieval. \n",
     "2. Then a task-driven agent to retrieve documents which can be invoked only when the orchestrator agent deems it necessary to fulfill the users request. \n",
     "3. Finally, a data retriever agent will query an embedding database containing Medical history if its deemed necessary to use this information to answer the users question.\n"
-   ],
-   "id": "ebed423080bc7eb4"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "### Dependencies and helper functions:",
-   "id": "4cd1dc31c9f5e39b"
+   "id": "4cd1dc31c9f5e39b",
+   "metadata": {},
+   "source": [
+    "### Dependencies and helper functions:"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "920dccd49d2398f4",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:41:27.790082Z",
+     "start_time": "2024-10-22T21:41:27.785846Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "from langchain.chains import create_history_aware_retriever, create_retrieval_chain\n",
     "from langchain.chains.combine_documents import create_stuff_documents_chain\n",
@@ -152,6 +192,7 @@
     "from io import StringIO\n",
     "import sys\n",
     "import textwrap\n",
+    "from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder\n",
     "\n",
     "warnings.filterwarnings('ignore')\n",
     "\n",
@@ -170,26 +211,31 @@
     "    for line in output.splitlines():\n",
     "        print(\"\\n\".join(textwrap.wrap(line, width=width)))\n",
     "        "
-   ],
-   "id": "920dccd49d2398f4",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "f588cc7b8894f329",
+   "metadata": {},
    "source": [
     "### Build the retriever chain to be used with LangGraph\n",
     "1. Create `create_retriever_pain` which is used when the solution requires data retrieval from our documents\n",
     "2. Define the system prompt to enforce the correct use of context retrieved, it also ensures that the agent does not hallucinate\n",
     "3. Define the vectorstore using FAISS, a light weight in-memory vector DB and our documents stored in _'medi_history.csv'_\n",
     "4. Define the sessions persistent memory store for the agents use"
-   ],
-   "id": "f588cc7b8894f329"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "6595db06c23fa9ee",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:41:28.564873Z",
+     "start_time": "2024-10-22T21:41:28.562052Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "store = {}\n",
     "def get_session_history(session_id: str) -> BaseChatMessageHistory:\n",
@@ -200,10 +246,10 @@
     "\n",
     "def create_retriever_pain():\n",
     "\n",
-    "    br_embeddings = BedrockEmbeddings(model_id=\"amazon.titan-embed-text-v1\", client=boto3_bedrock)\n",
+    "    br_embeddings = BedrockEmbeddings(model_id=\"amazon.titan-embed-text-v2:0\", client=boto3_bedrock)\n",
     "    \n",
-    "    loader = CSVLoader(\"./rag_data/medi_history.csv\") # --- > 219 docs with 400 chars, each row consists in a question column and an answer column\n",
-    "    documents_aws = loader.load() #\n",
+    "    loader = CSVLoader(\"./medi_history.csv\")\n",
+    "    documents_aws = loader.load() \n",
     "    print(f\"Number of documents={len(documents_aws)}\")\n",
     "\n",
     "    docs = CharacterTextSplitter(chunk_size=2000, chunk_overlap=400, separator=\",\").split_documents(documents_aws)\n",
@@ -218,7 +264,7 @@
     "    print(f\"vectorstore_faiss_aws: number of elements in the index={vectorstore_faiss_aws.index.ntotal}::\")\n",
     "\n",
     "    model_parameter = {\"temperature\": 0.0, \"top_p\": .5, \"max_tokens_to_sample\": 2000}\n",
-    "    modelId = \"meta.llama3-8b-instruct-v1:0\" #\"anthropic.claude-v2\"\n",
+    "    modelId = \"anthropic.claude-3-sonnet-20240229-v1:0\" #\"meta.llama3-8b-instruct-v1:0\" \n",
     "    chatbedrock_llm = ChatBedrock(\n",
     "        model_id=modelId,\n",
     "        client=boto3_bedrock,\n",
@@ -254,20 +300,27 @@
     "        output_messages_key=\"answer\",\n",
     "    )\n",
     "    return pain_retriever_chain\n"
-   ],
-   "id": "6595db06c23fa9ee",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "#### Testing the rag chain:",
-   "id": "c964d2f6a7c5f74c"
+   "id": "c964d2f6a7c5f74c",
+   "metadata": {},
+   "source": [
+    "#### Testing the rag chain:"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "64a6aeb779b1dad8",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:41:37.429789Z",
+     "start_time": "2024-10-22T21:41:29.561875Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "pain_rag_chain = create_retriever_pain()    \n",
     "result = pain_rag_chain.invoke(\n",
@@ -276,14 +329,12 @@
     "     config={'configurable': {'session_id': 'TEST-123'}},\n",
     ")\n",
     "result['answer']"
-   ],
-   "id": "64a6aeb779b1dad8",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "dd5958bbfaf0d282",
+   "metadata": {},
    "source": [
     "### Book / Cancel Appointments: An agent with tools:\n",
     "\n",
@@ -292,12 +343,19 @@
     "2. _cancel_appointment_: If an exiting appointment is found, it will remove its respective 'booking id' from the list of appointments.\n",
     "3. _reject_appointment_: If an appointment cannot be booked due to inability or invalid date or time the agent will use this tool to reject the users request.\n",
     "4. _need_more_info_: Returns the earliest date and time needed for the booking an appointment back to the agent as well as informing the agent that it should request further details from the user.\n"
-   ],
-   "id": "dd5958bbfaf0d282"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "561a6f83c40d33fb",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:41:39.663522Z",
+     "start_time": "2024-10-22T21:41:39.658624Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "from langchain.tools import tool\n",
     "from langchain.agents import AgentExecutor, create_tool_calling_agent\n",
@@ -340,9 +398,13 @@
     "        if 'ERROR' in is_valid :\n",
     "            return {\"status\" : False, \"date\": date, \"time\": time, \"booking_id\": is_valid}\n",
     "\n",
-    "        last_appointment = appointments[-1]\n",
-    "        new_appointment = f\"ID_{int(last_appointment[3:]) + 1}\"\n",
-    "        appointments.append(new_appointment)\n",
+    "        if appointments:\n",
+    "            last_appointment = appointments[-1]\n",
+    "            new_appointment = f\"ID_{int(last_appointment[3:]) + 1}\"\n",
+    "            appointments.append(new_appointment)\n",
+    "        else:\n",
+    "            new_appointment = \"ID_100\"\n",
+    "            appointments.append(new_appointment)\n",
     "            \n",
     "        return {\"status\" : True, \"date\": date, \"time\": time, \"booking_id\": new_appointment}\n",
     "    \n",
@@ -404,28 +466,42 @@
     "                                     max_iterations=5, \n",
     "                                     return_intermediate_steps=True)\n",
     "    return agent_executor_t\n"
-   ],
-   "id": "561a6f83c40d33fb",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "source": "appointments",
+   "execution_count": null,
    "id": "5085f454df936ab6",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:41:40.049463Z",
+     "start_time": "2024-10-22T21:41:40.047574Z"
+    }
+   },
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "appointments"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "### Test the Booking Agent with history:",
-   "id": "8ef9b197994867c"
+   "id": "8ef9b197994867c",
+   "metadata": {},
+   "source": [
+    "### Test the Booking Agent with history:"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "47ab5607e63637af",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:41:57.189142Z",
+     "start_time": "2024-10-22T21:41:40.850250Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "# Add context for the agent to use\n",
     "book_cancel_history = InMemoryChatMessageHistory()\n",
@@ -441,60 +517,91 @@
     "     \"chat_history\": book_cancel_history.messages}, \n",
     "    config={\"configurable\": {\"session_id\": \"session_1\"}}\n",
     ")"
-   ],
-   "id": "47ab5607e63637af",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "source": "result['output'][0]['text']",
+   "execution_count": null,
    "id": "9ff688418e6dd8f0",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:41:57.249133Z",
+     "start_time": "2024-10-22T21:41:57.247130Z"
+    }
+   },
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "result['output'][0]['text']"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "source": "book_cancel_history.messages",
+   "execution_count": null,
    "id": "d987b6d082233350",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:41:57.329913Z",
+     "start_time": "2024-10-22T21:41:57.327935Z"
+    }
+   },
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "book_cancel_history.messages"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "2bbe0f4b09bc4bfd",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:42:03.602810Z",
+     "start_time": "2024-10-22T21:41:57.406756Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "agent_executor_book_cancel.invoke(\n",
     "    {\"input\": \"can you book an appointment for me?\", \"chat_history\": []}, \n",
     "    config={\"configurable\": {\"session_id\": \"session_1\"}}\n",
     ")"
-   ],
-   "id": "2bbe0f4b09bc4bfd",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "source": "agent_executor_book_cancel.invoke({\"input\": \"can you cancel my appointment with booking id of ID_100\"})",
+   "execution_count": null,
    "id": "b43930e2a951f58d",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:42:19.451579Z",
+     "start_time": "2024-10-22T21:42:16.228791Z"
+    }
+   },
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "agent_executor_book_cancel.invoke({\"input\": \"can you cancel my appointment with booking id of ID_100\"})"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "bf3da629cf9efe25",
+   "metadata": {},
    "source": [
     "### An AI doctor: Medical advice agent based on conversations with the patient\n",
     "This function will be the backbone of the language agent responsible for giving medical advice given the historical interactions the user had with the Chatbot. This model will use its knowledge of the medical field along with the conversations with the patient to give well founded advice."
-   ],
-   "id": "bf3da629cf9efe25"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "78ae10938d36cfde",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:42:28.217525Z",
+     "start_time": "2024-10-22T21:42:28.214653Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "from langchain_aws.chat_models.bedrock import ChatBedrock\n",
     "\n",
@@ -520,44 +627,56 @@
     "    )\n",
     "    response_body = response['output']['message']['content'][0]['text']\n",
     "    return response_body\n"
-   ],
-   "id": "78ae10938d36cfde",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "### Testing the AI Doc agent",
-   "id": "dcac44e7a7736d97"
+   "id": "dcac44e7a7736d97",
+   "metadata": {},
+   "source": [
+    "### Testing the AI Doc agent"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "45d9fd27140a6d12",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:42:32.979507Z",
+     "start_time": "2024-10-22T21:42:30.718749Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "chat_history=InMemoryChatMessageHistory()\n",
     "chat_history.add_user_message(\"what are the effects of Asprin\")\n",
     "ask_doctor_advice(boto3_bedrock, extract_chat_history(chat_history.messages))"
-   ],
-   "id": "45d9fd27140a6d12",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "b3db4c014b3e75d3",
+   "metadata": {},
    "source": [
     "### The supervisor agent, the orchestrator of the LangGraph workflow\n",
     "1. This agent has the list of tools / nodes it can invoke based on the nodes\n",
     "2. Based on that the supervisor will route and invoke the correct LangGraph chain and node\n",
     "3. Output will be a predefine chain of thought leveraging the available tools and agents to complete and validate the task\n",
     "4. `ToolsAgentOutputParser` is used to parse the output of the tools"
-   ],
-   "id": "b3db4c014b3e75d3"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "26a8f54c32cabf28",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:42:35.041504Z",
+     "start_time": "2024-10-22T21:42:35.038985Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "from langchain_core.runnables import RunnablePassthrough\n",
     "from langchain.agents.output_parsers.tools import ToolsAgentOutputParser\n",
@@ -597,23 +716,23 @@
     "    return supervisor_chain_t\n",
     "\n",
     "supervisor_wrapped_chain = create_supervisor_agent()\n"
-   ],
-   "id": "26a8f54c32cabf28",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "49944e6286a15534",
+   "metadata": {},
    "source": [
     "### Test the supervisor agent\n",
     "Our supervisor will litigate the user query to the respective agent or end the chain."
-   ],
-   "id": "49944e6286a15534"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "43bf9e73e8ef813f",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "temp_messages = InMemoryChatMessageHistory()\n",
     "temp_messages.add_user_message(\"What does medical doctor do?\")\n",
@@ -635,31 +754,37 @@
     "    \"history_chat\": extract_chat_history(temp_message_2.messages)})\n",
     "\n",
     "response"
-   ],
-   "id": "43bf9e73e8ef813f",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "1ee3d86185b0af5f",
+   "metadata": {},
    "source": [
     "### Putting it all together: Defining the Graph architecture\n",
     "1. The `GraphState` class defines how we want our nodes to behave  \n",
     "2. Wrap our agents into nodes that will take a graph state as input\n",
     "3. Short term or 'buffer' memory for the graph will be provided by the `ConversationBufferMemory` object\n",
     "4. Finally `add_user_message` and `add_ai_message` apis are used to add the messages to the buffer memory"
-   ],
-   "id": "1ee3d86185b0af5f"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "2e3b24e4572078bc",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:42:43.823690Z",
+     "start_time": "2024-10-22T21:42:43.776931Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "import operator\n",
     "from typing import Annotated, Dict, Sequence, TypedDict\n",
     "from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder\n",
     "from langgraph.graph import StateGraph, END\n",
+    "from langgraph.graph.message import add_messages\n",
     "from langchain_core.messages import BaseMessage\n",
     "from langchain_core.chat_history import InMemoryChatMessageHistory\n",
     "\n",
@@ -668,11 +793,9 @@
     "class GraphState(TypedDict):\n",
     "    # The annotation tells the graph that new messages will always\n",
     "    # be added to the current states\n",
-    "    messages: Annotated[Sequence[BaseMessage], operator.add]\n",
+    "    messages: Annotated[list, add_messages] # Annotated[Sequence[BaseMessage], operator.add]\n",
     "    # The 'next_node' field indicates where to route to next\n",
     "    next_node: str\n",
-    "    # initial user query\n",
-    "    user_query: str\n",
     "    # instantiate memory\n",
     "    convo_memory: InMemoryChatMessageHistory\n",
     "    # options for the supervisor agent to decide which node to follow\n",
@@ -680,12 +803,19 @@
     "    # session id for the supervisor since that is another option for managing memory\n",
     "    curr_session_id: str \n",
     "\n",
+    "graph_store = {}\n",
+    "\n",
+    "def get_graph_session_history(session_id):\n",
+    "    if session_id not in graph_store:\n",
+    "        graph_store[session_id] = InMemoryChatMessageHistory()\n",
+    "    return graph_store[session_id]\n",
     "\n",
     "def input_first(state: GraphState) -> Dict[str, str]:\n",
     "    print_ww(f\"\"\"start input_first()....::state={state}::\"\"\")\n",
-    "    init_input = state.get(\"user_query\", \"\").strip()\n",
+    "    init_input = state[\"messages\"][-1].content # state.get(\"user_query\", \"\").strip()\n",
     "    # store the input\n",
-    "    convo_memory =  InMemoryChatMessageHistory()\n",
+    "    # convo_memory =  InMemoryChatMessageHistory()\n",
+    "    convo_memory = get_graph_session_history(state[\"curr_session_id\"])\n",
     "    convo_memory.add_user_message(init_input)\n",
     "    options = ['FINISH', 'book_cancel_agent', 'pain_retriever_chain', 'ask_doctor_advice'] \n",
     "    return {\"user_query\":init_input, \"options\": options, \"convo_memory\": convo_memory}\n",
@@ -700,7 +830,7 @@
     "def retriever_node(state: GraphState) -> Dict[str, str]:\n",
     "    global pain_rag_chain\n",
     "    print_ww(f\"use this to go the retriever way to answer the question():: state::{state}\")    \n",
-    "    init_input = state.get(\"user_query\", \"\").strip()\n",
+    "    init_input = state[\"messages\"][-1].content # state.get(\"user_query\", \"\").strip()\n",
     "    chat_history = extract_chat_history(state.get(\"convo_memory\").messages)\n",
     "    if pain_rag_chain == None:\n",
     "        pain_rag_chain = create_retriever_pain()    \n",
@@ -708,7 +838,7 @@
     "    # This agent is used to get the context for any questions related to medical issues such as aches, headache or body pain\n",
     "    result = pain_rag_chain.invoke(\n",
     "        {\"input\": init_input, \"chat_history\": chat_history},\n",
-    "        config={'configurable': {'session_id': 'TEST-123'}}\n",
+    "        config={'configurable': {'session_id': state[\"curr_session_id\"]}}\n",
     "    )\n",
     "    return agent_node(state, result['answer'], 'pain_retriever_chain')\n",
     "\n",
@@ -724,12 +854,12 @@
     "def book_cancel_node(state: GraphState) -> Dict[str, str]:\n",
     "    global book_cancel_agent, agent_executor_book_cancel\n",
     "    print_ww(f\"use this to book or cancel an appointment::{state}::\")\n",
-    "    init_input = state.get(\"user_query\", \"\").strip()\n",
+    "    init_input = state[\"messages\"][-1].content # state.get(\"user_query\", \"\").strip()\n",
     "    agent_executor_book_cancel = create_book_cancel_agent()\n",
     "    \n",
     "    result = agent_executor_book_cancel.invoke(\n",
     "        {\"input\": init_input, \"chat_history\": state.get(\"convo_memory\").messages}, \n",
-    "        config={\"configurable\": {\"session_id\": \"session_1\"}}\n",
+    "        config={\"configurable\": {\"session_id\": state[\"curr_session_id\"]}}\n",
     "    ) \n",
     "    ret_val = result['output'][0]['text']\n",
     "    return agent_node(state, ret_val, name=\"book_cancel_agent\")\n",
@@ -743,7 +873,7 @@
     "def supervisor_node(state: GraphState) -> Dict[str, str]:\n",
     "    global supervisor_wrapped_chain\n",
     "    print_ww(f\"\"\"supervisor_node()::state={state}::\"\"\") \n",
-    "    init_input = state.get(\"user_query\", \"\").strip()\n",
+    "    init_input = state[\"messages\"][-1].content # state.get(\"user_query\", \"\").strip()\n",
     "    options = state.get(\"options\", ['FINISH', 'book_cancel_agent', 'pain_retriever_chain', 'ask_doctor_advice']  )\n",
     "\n",
     "    convo_memory = state.get(\"convo_memory\")\n",
@@ -758,23 +888,28 @@
     "\n",
     "    print_ww(f\"\\n\\nsupervisor_node():result={result}......\\n\\n\")\n",
     "    return {\"next_node\": result.return_values[\"output\"]}\n"
-   ],
-   "id": "2e3b24e4572078bc",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "def3293b1a9cfb5f",
+   "metadata": {},
    "source": [
     "## Set up the workflow:\n",
     "LangGraph works by seamlessly knitting together our agents into a coherent workflow allowing us to set up the flow that is essential for agentic architectures. "
-   ],
-   "id": "def3293b1a9cfb5f"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "9b8a673858c236f9",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:42:47.950634Z",
+     "start_time": "2024-10-22T21:42:47.945593Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "workflow = StateGraph(GraphState)\n",
     "workflow.add_node(\"pain_retriever_chain\", retriever_node)\n",
@@ -803,139 +938,159 @@
     "workflow.set_entry_point(\"init_input\") \n",
     "\n",
     "graph = workflow.compile()"
-   ],
-   "id": "9b8a673858c236f9",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "##### Finally, we visualize the entire workflow to make sure it meets our expectations. In our usecase the supervisor can 'litigate' the work to other agents or end the workflow itself.",
-   "id": "3b0dc85d35ecd52c"
+   "id": "3b0dc85d35ecd52c",
+   "metadata": {},
+   "source": [
+    "##### Finally, we visualize the entire workflow to make sure it meets our expectations. In our usecase the supervisor can 'litigate' the work to other agents or end the workflow itself."
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "source": "graph.get_graph().print_ascii()",
+   "execution_count": null,
    "id": "ea00c6396596d008",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:42:51.805767Z",
+     "start_time": "2024-10-22T21:42:51.790365Z"
+    }
+   },
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "graph.get_graph().print_ascii()"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "source": [
-    "graph.invoke(\n",
-    "    {\"user_query\": \"what is the general function of a doctor, what do they do?\", \"recursion_limit\": 2, \"curr_session_id\": \"session_1\"},\n",
-    ")"
-   ],
+   "execution_count": null,
    "id": "bdb0cd15aac33fd",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:42:55.944149Z",
+     "start_time": "2024-10-22T21:42:52.711488Z"
+    }
+   },
    "outputs": [],
-   "execution_count": null
-  },
-  {
-   "metadata": {},
-   "cell_type": "code",
    "source": [
     "graph.invoke(\n",
-    "    {\"user_query\": \"what are the effects of Asprin?\", \"recursion_limit\": 2, \"curr_session_id\": \"session_1\"},\n",
+    "    {\"messages\": \"what is the general function of a doctor, what do they do?\", \"recursion_limit\": 2, \"curr_session_id\": \"session_1\"},\n",
     ")"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "14171b337171ccbc",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T21:42:59.197140Z",
+     "start_time": "2024-10-22T21:42:57.428489Z"
+    }
+   },
    "outputs": [],
-   "execution_count": null
-  },
-  {
-   "metadata": {},
-   "cell_type": "code",
    "source": [
     "graph.invoke(\n",
-    "    {\"user_query\": \"what is the general function of a doctor, what do they do?\", \"recursion_limit\": 2, \"curr_session_id\": \"session_1\"},\n",
+    "    {\"messages\": \"what are the effects of Asprin?\", \"recursion_limit\": 2, \"curr_session_id\": \"session_1\"},\n",
     ")"
-   ],
-   "id": "d1e089034d26597d",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "source": [
-    "graph.invoke(\n",
-    "    {\"user_query\": \"Can you book an appointment for me?\", \"recursion_limit\": 2, \"curr_session_id\": \"session_1\"},\n",
-    ")"
-   ],
+   "execution_count": null,
    "id": "cb0617c2b2e02104",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
    "metadata": {},
-   "cell_type": "code",
+   "outputs": [],
    "source": [
     "graph.invoke(\n",
-    "    {\"user_query\": \"Can you book an appointment for Sept 24, 2024 10 am?\", \"recursion_limit\": 2, \"curr_session_id\": \"session_1\"},\n",
+    "    {\"messages\": \"Can you book an appointment for me?\", \"recursion_limit\": 2, \"curr_session_id\": \"session_1\"},\n",
     ")"
-   ],
-   "id": "51426ef2e21ce8cf",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "source": "appointments",
+   "execution_count": null,
    "id": "4c88cfba4e344cf2",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
    "metadata": {},
-   "cell_type": "code",
+   "outputs": [],
    "source": [
     "graph.invoke(\n",
-    "    {\"user_query\": \"can you cancel my appointment with booking id of ID_100\", \"recursion_limit\": 2, \"curr_session_id\": \"session_1\"},\n",
+    "    {\"messages\": \"Can you book an appointment for November 4, 2024 10 am?\", \"recursion_limit\": 2, \"curr_session_id\": \"session_1\"},\n",
     ")"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db814e08-35e5-4ee3-9878-4137299d3da8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "appointments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51426ef2e21ce8cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph.invoke(\n",
+    "    {\"messages\": \"Can you book an appointment for Sept 24, 2024 10 am?\", \"recursion_limit\": 2, \"curr_session_id\": \"session_1\"},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "399b9cb9993df34e",
+   "metadata": {},
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "graph.invoke(\n",
+    "    {\"messages\": \"can you cancel my appointment with booking id of ID_100\", \"recursion_limit\": 2, \"curr_session_id\": \"session_1\"},\n",
+    ")"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "source": "appointments",
+   "execution_count": null,
    "id": "952f1bbbd94ffed",
+   "metadata": {},
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "appointments"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "source": "",
+   "execution_count": null,
    "id": "ab3b62013c50da85",
+   "metadata": {},
    "outputs": [],
-   "execution_count": null
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
…y for different invocations

*Issue #, if available:*

*Description of changes:*
The main change is in the GraphState:
- use the "messages" channel to pass and accumulate messages
- create an external store to keep track of conversation history across invocations based on session_id

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
