### PR TITLE
Fixed seaborn install for multimodal embeddings lab

### DIFF
--- a/04_Image_and_Multimodal/bedrock-titan-multimodal-embeddings.ipynb
+++ b/04_Image_and_Multimodal/bedrock-titan-multimodal-embeddings.ipynb
@@ -27,6 +27,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7d33343d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install seaborn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "8ef07a00-9f50-44d2-bdf4-f0a09dfd7152",
    "metadata": {
     "tags": []


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added
```
 %pip install seaborn 
```
for multimodal embeddings lab. This lab was failing on `import seaborn as sns`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
