### PR TITLE
Fixes for legacy issues in modules 00 and 01

### DIFF
--- a/00_Prerequisites/bedrock_basics.ipynb
+++ b/00_Prerequisites/bedrock_basics.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Amazon Bedrock boto3 Prerequisites\n",
     "\n",
-    "> *This notebook should work well with the **`SageMaker Distribution 2.1`** kernel in SageMaker Studio*\n",
+    "> *This notebook should work well with the **`Python 3`** kernel from **`SageMaker Distribution 2.1`** in SageMaker Studio*\n",
     "\n",
     "---\n",
     "\n",

--- a/00_Prerequisites/bedrock_basics.ipynb
+++ b/00_Prerequisites/bedrock_basics.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Amazon Bedrock boto3 Prerequisites\n",
     "\n",
-    "> *This notebook should work well with the **`Data Science 3.0`** kernel in SageMaker Studio*\n",
+    "> *This notebook should work well with the **`SageMaker Distribution 2.1`** kernel in SageMaker Studio*\n",
     "\n",
     "---\n",
     "\n",
@@ -356,7 +356,7 @@
     "tags": []
    },
    "source": [
-    "### Amazon Titan Large and Premier\n",
+    "### Amazon Titan Text models\n",
     "\n",
     "#### Input\n",
     "```json\n",
@@ -389,18 +389,24 @@
    "id": "7adb6bee-7654-4269-9127-9afa4e823454",
    "metadata": {},
    "source": [
-    "### Anthropic Claude\n",
+    "### Anthropic Claude 3 (Messages API)\n",
     "\n",
     "#### Input\n",
     "\n",
     "```json\n",
     "{\n",
-    "    \"prompt\": \"\\n\\nHuman:<prompt>\\n\\nAnswer:\",\n",
-    "    \"max_tokens_to_sample\": 300,\n",
-    "    \"temperature\": 0.5,\n",
-    "    \"top_k\": 250,\n",
-    "    \"top_p\": 1,\n",
-    "    \"stop_sequences\": [\"\\n\\nHuman:\"]\n",
+    "    \"anthropic_version\" : \"bedrock-2023-05-31\",\n",
+    "    \"max_tokens\" : 4096,\n",
+    "    \"temperature\" : 0.5,\n",
+    "    \"top_k\" : 250,\n",
+    "    \"top_p\" : 0.99,\n",
+    "    \"messages\" : [\n",
+    "        {\n",
+    "            \"role\" : \"user\",\n",
+    "            \"content\" : [ {\"type\" : \"text\", \"text\" : \"<prompt>\"} ]\n",
+    "        }\n",
+    "    ]\n",
+    "\n",
     "}\n",
     "```\n",
     "\n",
@@ -408,8 +414,16 @@
     "\n",
     "```json\n",
     "{\n",
-    "    \"completion\": \"<output>\",\n",
-    "    \"stop_reason\": \"stop_sequence\"\n",
+    "    \"id\": \"<id>\",\n",
+    "    \"type\": \"message\",\n",
+    "    \"role\": \"assistant\",\n",
+    "    \"model\": \"<model_id>\",\n",
+    "    \"content\": [\n",
+    "        { \"type\": \"text\", \"text\": \"<output>\" }      \n",
+    "    ],\n",
+    "    \"stop_reason\": \"end_turn\",\n",
+    "    \"stop_sequence\": null,\n",
+    "    \"usage\": { \"input_tokens\": <input_tokens>, \"output_tokens\": <output_tokens>}\n",
     "}\n",
     "```"
    ]
@@ -554,7 +568,7 @@
     "tags": []
    },
    "source": [
-    "### Amazon Titan Text Premier"
+    "### Amazon Titan Text"
    ]
   },
   {
@@ -583,7 +597,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "dd2bb671-6b10-4948-9e5e-95d6ced3b86f",
    "metadata": {
     "tags": []
@@ -603,8 +617,8 @@
    "source": [
     "try:\n",
     "\n",
-    "    body = json.dumps({\"inputText\": prompt_data, \"textGenerationConfig\" : {\"topP\":0.95, \"temperature\":0.2}})\n",
-    "    modelId = \"amazon.titan-tg1-large\" # \n",
+    "    body = json.dumps({\"inputText\": prompt_data, \"textGenerationConfig\" : {\"maxTokenCount\": 1024, \"topP\":0.95, \"temperature\":0.2}})\n",
+    "    modelId = \"amazon.titan-text-express-v1\" # \"amazon.titan-tg1-large\"\n",
     "    accept = \"application/json\"\n",
     "    contentType = \"application/json\"\n",
     "\n",
@@ -759,7 +773,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "c69627e3",
    "metadata": {
     "tags": []
@@ -788,8 +802,8 @@
     "Blog:\n",
     "\"\"\"\n",
     "\n",
-    "body = json.dumps({\"inputText\": prompt_data})\n",
-    "modelId = \"amazon.titan-tg1-large\"  # (Change this, and the request body, to try different models)\n",
+    "body = json.dumps({\"inputText\": prompt_data, \"textGenerationConfig\" : {\"maxTokenCount\": 1024, \"topP\":0.95, \"temperature\":0.2}})\n",
+    "modelId = \"amazon.titan-text-express-v1\" # \"amazon.titan-tg1-large\"\n",
     "accept = \"application/json\"\n",
     "contentType = \"application/json\"\n",
     "\n",
@@ -831,7 +845,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "bd800ef5-78f7-43d4-b73e-c37c7609cb40",
    "metadata": {
     "tags": []
@@ -839,9 +853,7 @@
    "outputs": [],
    "source": [
     "# If you'd like to try your own prompt, edit this parameter!\n",
-    "prompt_data = \"\"\"Human: Write me 500 word paragraph about making strong business decisions as a leader.\n",
-    "\n",
-    "Assistant:\n",
+    "prompt_data = \"\"\"Write me a 500 word paragraph about making strong business decisions as a leader.\n",
     "\"\"\"\n"
    ]
   },

--- a/01_Text_generation/00_text_generation_w_bedrock.ipynb
+++ b/01_Text_generation/00_text_generation_w_bedrock.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# Invoke Bedrock model for text generation using zero-shot prompt\n",
     "\n",
-    "> *This notebook should work well with the **`Python 3`** kernel in SageMaker Studio*"
+    "> *This notebook should work well with the **`SageMaker Distribution 2.1`** kernel in SageMaker Studio*"
    ]
   },
   {
@@ -170,7 +170,7 @@
    "outputs": [],
    "source": [
     "# modelId = 'amazon.titan-text-premier-v1:0' # Make sure Titan text premier is available in the account you are doing this workhsop in before uncommenting!\n",
-    "modelId = \"amazon.titan-tg1-large\"\n",
+    "modelId = \"amazon.titan-text-express-v1\"\n",
     "accept = \"application/json\"\n",
     "contentType = \"application/json\"\n",
     "outputText = \"\\n\"\n",

--- a/01_Text_generation/00_text_generation_w_bedrock.ipynb
+++ b/01_Text_generation/00_text_generation_w_bedrock.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# Invoke Bedrock model for text generation using zero-shot prompt\n",
     "\n",
-    "> *This notebook should work well with the **`SageMaker Distribution 2.1`** kernel in SageMaker Studio*"
+    "> *This notebook should work well with the **`Python 3`** kernel from **`SageMaker Distribution 2.1`** in SageMaker Studio*"
    ]
   },
   {
@@ -123,7 +123,7 @@
     "body = json.dumps(\n",
     "    {\n",
     "        \"inputText\": prompt_data,\n",
-    "        \"textGenerationConfig\": {\"topP\": 0.95, \"temperature\": 0.1},\n",
+    "        \"textGenerationConfig\": {\"maxTokenCount\": 1024, \"topP\": 0.95, \"temperature\": 0.1},\n",
     "    }\n",
     ")"
    ]
@@ -170,7 +170,7 @@
    "outputs": [],
    "source": [
     "# modelId = 'amazon.titan-text-premier-v1:0' # Make sure Titan text premier is available in the account you are doing this workhsop in before uncommenting!\n",
-    "modelId = \"amazon.titan-text-express-v1\"\n",
+    "modelId = \"amazon.titan-text-express-v1\"  # \"amazon.titan-tg1-large\"\n",
     "accept = \"application/json\"\n",
     "contentType = \"application/json\"\n",
     "outputText = \"\\n\"\n",

--- a/01_Text_generation/01_code_generation_w_bedrock.ipynb
+++ b/01_Text_generation/01_code_generation_w_bedrock.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# Invoke Bedrock model for code generation\n",
     "\n",
-    "> *This notebook should work well with the **`Python 3`** kernel in SageMaker Studio*"
+    "> *This notebook should work well with the **`Python 3`** kernel from **`SageMaker Distribution 2.1`** in SageMaker Studio*"
    ]
   },
   {
@@ -359,8 +359,7 @@
    "source": [
     "# create the prompt to generate SQL query\n",
     "prompt_data = \"\"\"\n",
-    "\n",
-    "Human: AnyCompany has a database with a table named sales_data containing sales records. The table has following columns:\n",
+    "AnyCompany has a database with a table named sales_data containing sales records. The table has following columns:\n",
     "- date (YYYY-MM-DD)\n",
     "- product_id\n",
     "- price\n",
@@ -369,8 +368,6 @@
     "Can you generate SQL queries for the below: \n",
     "- Identify the top 5 best selling products by total sales for the year 2023\n",
     "- Calculate the average of total monthly sales for the year 2023\n",
-    "\n",
-    "Assistant:\n",
     "\"\"\"\n"
    ]
   },

--- a/01_Text_generation/02_text-summarization-titan+claude.ipynb
+++ b/01_Text_generation/02_text-summarization-titan+claude.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Text summarization with small files with Amazon Titan\n",
     "\n",
-    "> *This notebook should work well with the **`SageMaker Distribution 2.1`** kernel in SageMaker Studio*"
+    "> *This notebook should work well with the **`Python 3`** kernel from **`SageMaker Distribution 2.1`** in SageMaker Studio*"
    ]
   },
   {

--- a/01_Text_generation/02_text-summarization-titan+claude.ipynb
+++ b/01_Text_generation/02_text-summarization-titan+claude.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Text summarization with small files with Amazon Titan\n",
     "\n",
-    "> *This notebook should work well with the **`Python 3`** kernel in SageMaker Studio*"
+    "> *This notebook should work well with the **`SageMaker Distribution 2.1`** kernel in SageMaker Studio*"
    ]
   },
   {

--- a/01_Text_generation/03_qa_with_bedrock_titan.ipynb
+++ b/01_Text_generation/03_qa_with_bedrock_titan.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Question and answers with Bedrock\n",
     "\n",
-    "> *This notebook should work well with the **`SageMaker Distribution 2.1`** kernel in SageMaker Studio*\n",
+    "> *This notebook should work well with the **`Python 3`** kernel from **`SageMaker Distribution 2.1`** in SageMaker Studio*\n",
     "\n",
     "Question Answering (QA) is an important task that involves extracting answers to factual queries posed in natural language. Typically, a QA system processes a query against a knowledge base containing structured or unstructured data and generates a response with accurate information. Ensuring high accuracy is key to developing a useful, reliable and trustworthy question answering system, especially for enterprise use cases. \n",
     "\n",

--- a/01_Text_generation/03_qa_with_bedrock_titan.ipynb
+++ b/01_Text_generation/03_qa_with_bedrock_titan.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Question and answers with Bedrock\n",
     "\n",
-    "> *This notebook should work well with the **`Python 3`** kernel in SageMaker Studio*\n",
+    "> *This notebook should work well with the **`SageMaker Distribution 2.1`** kernel in SageMaker Studio*\n",
     "\n",
     "Question Answering (QA) is an important task that involves extracting answers to factual queries posed in natural language. Typically, a QA system processes a query against a knowledge base containing structured or unstructured data and generates a response with accurate information. Ensuring high accuracy is key to developing a useful, reliable and trustworthy question answering system, especially for enterprise use cases. \n",
     "\n",

--- a/01_Text_generation/04_entity_extraction.ipynb
+++ b/01_Text_generation/04_entity_extraction.ipynb
@@ -345,8 +345,7 @@
    "outputs": [],
    "source": [
     "prompt = \"\"\"\n",
-    "\n",
-    "Human: Given email provided , please read it and analyse the contents.\n",
+    "Given email provided , please read it and analyse the contents.\n",
     "\n",
     "Please extract the following information from the email:\n",
     "- Any questions the customer is asking, return it inside <questions></questions> XML tags.\n",
@@ -364,8 +363,7 @@
     "\n",
     "Return each question inside <question></question> XML tags.\n",
     "Return the name of each book inside <book></book> XML tags.\n",
-    "\n",
-    "Assistant:\"\"\""
+    "\"\"\""
    ]
   },
   {

--- a/01_Text_generation/04_entity_extraction.ipynb
+++ b/01_Text_generation/04_entity_extraction.ipynb
@@ -7,16 +7,16 @@
    "source": [
     "# Entity Extraction with Claude\n",
     "\n",
-    "> *This notebook should work well with the **`Python 3`** kernel in SageMaker Studio*\n",
+    "> *This notebook should work well with the **`Python 3`** kernel from **`SageMaker Distribution 2.1`** in SageMaker Studio*\n",
     "\n",
     "### Context\n",
     "Entity extraction is an NLP technique that allows us to automatically extract specific data from naturally written text, such as news, emails, books, etc.\n",
     "That data can then later be saved to a database, used for lookup or any other type of processing.\n",
     "\n",
     "Classic entity extraction programs usually limit you to pre-defined classes, such as name, address, price, etc. or require you to provide many examples of types of entities you are interested in.\n",
-    "By using a LLM for entity extraction in most cases you are only required to specify what you need to extract in natural language. This gives you flexibility and accuracy in your queries while saving time by removing necessity of data labeling.\n",
+    "By using a LLM for entity extraction, in most cases you are only required to specify what you need to extract in natural language. This gives you flexibility and accuracy in your queries, while saving time by removing the need for data labeling.\n",
     "\n",
-    "In addition, LLM entity extraction can be used to help you assemble a dataset to later create a customised solution for your use case, such as [Amazon Comprehend custom entity](https://docs.aws.amazon.com/comprehend/latest/dg/custom-entity-recognition.html) recognition."
+    "In addition, LLM entity extraction can be used to help you assemble a dataset to create a customised solution for your use case, such as [Amazon Comprehend custom entity](https://docs.aws.amazon.com/comprehend/latest/dg/custom-entity-recognition.html) recognition."
    ]
   },
   {
@@ -25,19 +25,6 @@
    "metadata": {},
    "source": [
     "## Setup\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3dcc1624-19bf-4a3d-857a-89776dc74c3c",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "%pip install -U langchain-aws=='0.1.17'"
    ]
   },
   {
@@ -61,51 +48,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1fb9074b-d72e-4419-9165-421414d28f4b",
-   "metadata": {},
-   "source": [
-    "## Configure langchain\n",
-    "\n",
-    "We begin with instantiating the LLM. Here we are using Anthropic Claude v3 for text generation.\n",
-    "\n",
-    "Note: It is possible to choose other models available with Bedrock. For example, you can replace the `model_id` as follows to change the model to Titan Text Premier. Make sure your account has access to the model you want to try out before trying this!\n",
-    "\n",
-    "`llm = ChatBedrock(model_id=\"amazon.titan-text-premier-v1:0\")`\n",
-    "\n",
-    "Check [documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids-arns.html) for Available text generation model Ids under Amazon Bedrock."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "621790c0-332a-4bab-bf81-967a63cb52fa",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from langchain_aws import ChatBedrock\n",
-    "\n",
-    "llm = ChatBedrock(\n",
-    "    model_id=\"anthropic.claude-3-sonnet-20240229-v1:0\",\n",
-    "    model_kwargs={\n",
-    "        \"max_tokens\": 200,\n",
-    "        \"temperature\": 0, # Using 0 to get reproducible results\n",
-    "        \"stop_sequences\": [\"\\n\\nHuman:\"]\n",
-    "    }\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "5f85e961-3530-4bf4-ac28-12611965d408",
    "metadata": {},
    "source": [
     "## Entity Extraction\n",
-    "Now that we have our LLM initialised, we can start extracting entities.\n",
     "\n",
     "For this exercise we will pretend to be an online bookstore that receives questions and orders by email.\n",
-    "Our task would be to extract relevant information from the email to process the order.\n",
+    "Our task is to extract relevant information from the email to process the order.\n",
     "\n",
     "Let's begin by taking a look at the sample email:"
    ]
@@ -135,8 +84,48 @@
    "source": [
     "### Basic approach\n",
     "\n",
-    "For basic cases we can directly ask the model to return the result.\n",
-    "Let's try extracting the name of the book."
+    "First, let's define a function to process queries using Claude 3. In the below, we use a system prompt to tell the\n",
+    "LLM to act as a bookstore assistant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae924e1f-6ed7-489b-b79d-d6b68e5fa750",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def bookstore_assistant(query: str) -> str:\n",
+    "    body = json.dumps({\n",
+    "        \"anthropic_version\": \"bedrock-2023-05-31\",\n",
+    "        \"max_tokens\": 4096,\n",
+    "        \"temperature\": 0.1,\n",
+    "        \"top_k\":250,\n",
+    "        \"top_p\":0.99,\n",
+    "        \"system\": \"You are a helpful assistant that processes orders from a bookstore.\",\n",
+    "        \"messages\": [\n",
+    "            {\n",
+    "                \"role\": \"user\",\n",
+    "                \"content\": [{\"type\": \"text\", \"text\": query}]\n",
+    "            }\n",
+    "        ],\n",
+    "    })\n",
+    "    modelId = \"anthropic.claude-3-sonnet-20240229-v1:0\"\n",
+    "    accept = 'application/json'\n",
+    "    contentType = 'application/json'\n",
+    "\n",
+    "    response = boto3_bedrock.invoke_model(body=body, modelId=modelId, accept=accept, contentType=contentType)\n",
+    "    response_body = json.loads(response.get('body').read())\n",
+    "\n",
+    "    return response_body[\"content\"][0][\"text\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b80d754-4add-4dee-a607-55f7a95f61e9",
+   "metadata": {},
+   "source": [
+    "For basic cases we can directly ask the model to return the result. Let's try extracting the name of the book."
    ]
   },
   {
@@ -156,15 +145,7 @@
     "{book_question_email}\n",
     "```\n",
     "\n",
-    "\"\"\"\n",
-    "\n",
-    "messages = [\n",
-    "    (\n",
-    "        \"system\",\n",
-    "        \"You are a helpful assistant that processes orders from a bookstore.\",\n",
-    "    ),\n",
-    "    (\"human\", query),\n",
-    "]"
+    "\"\"\"\n"
    ]
   },
   {
@@ -176,8 +157,8 @@
    },
    "outputs": [],
    "source": [
-    "result = llm.invoke(messages)\n",
-    "print(result.content)"
+    "result = bookstore_assistant(query)\n",
+    "print(result)"
    ]
   },
   {
@@ -215,7 +196,8 @@
     "\n",
     "Return the name of the book between <book></book> XML tags.\n",
     "\n",
-    "\"\"\""
+    "\"\"\"\n",
+    "query = prompt.format(email=book_question_email)"
    ]
   },
   {
@@ -227,15 +209,7 @@
    },
    "outputs": [],
    "source": [
-    "query = prompt.format(email=book_question_email)\n",
-    "messages = [\n",
-    "    (\n",
-    "        \"system\",\n",
-    "        \"You are a helpful assistant that processes orders from a bookstore.\",\n",
-    "    ),\n",
-    "    (\"human\", query),\n",
-    "]\n",
-    "result = llm.invoke(messages).content\n",
+    "result = bookstore_assistant(query)\n",
     "print(result)"
    ]
   },
@@ -315,14 +289,7 @@
    "outputs": [],
    "source": [
     "query = prompt.format(email=return_email)\n",
-    "messages = [\n",
-    "    (\n",
-    "        \"system\",\n",
-    "        \"You are a helpful assistant that processes orders from a bookstore.\",\n",
-    "    ),\n",
-    "    (\"human\", query),\n",
-    "]\n",
-    "result = llm.invoke(query).content\n",
+    "result = bookstore_assistant(query)\n",
     "print(result)"
    ]
   },
@@ -376,14 +343,7 @@
    "outputs": [],
    "source": [
     "query = prompt.format(email=book_question_email)\n",
-    "messages = [\n",
-    "    (\n",
-    "        \"system\",\n",
-    "        \"You are a helpful assistant that processes orders from a bookstore.\",\n",
-    "    ),\n",
-    "    (\"human\", query),\n",
-    "]\n",
-    "result = llm.invoke(query).content\n",
+    "result = bookstore_assistant(query)\n",
     "print(result)"
    ]
   },
@@ -439,14 +399,6 @@
     "- Change the prompts to your specific usecase and evaluate the output of different models.\n",
     "- Apply different prompt engineering principles to get better outputs. Refer to the prompt guide for your chosen model for recommendations, e.g. [here is the prompt guide for Claude](https://docs.anthropic.com/claude/docs/introduction-to-prompt-design)."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "95bf2beb-c2d1-4aef-acb4-83eec89569e2",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Modules 00 and 01 contained some inconsistences/defects left over from older versions. The following have been fixed:

1. As the workshop now uses Claude 3 (instead of the older Claude 2), the Messages API is used throughout. Therefore there is no need to include "Human:" and "Assistant:" indicators in any prompts, and these have been removed. Also the format of the request / response (in `00_Prerequisites/bedrock_basics` for Claude 3 has been updated to reflect the Messages API.

2. References to the `Data Science 3.0` or `Python 3` kernels have been replaced with `SageMaker Distribution 2.1`.

3. Some of the Titan text examples were not generating complete output because the default `maxTokenCount` was too short. This is now set explicitly to a larger value of 1024.

4. References to `titan-tg1-large` have been replaced with the newer `titan-text-express-v1`. While `titan-tg1-large` works, it does not appear anywhere in AWS documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
