### PR TITLE
Minor correction on agent section: datetime object non serializability error

### DIFF
--- a/05_Agents/02_associate_knowledge_base_to_agent.ipynb
+++ b/05_Agents/02_associate_knowledge_base_to_agent.ipynb
@@ -359,7 +359,7 @@
     "%%time\n",
     "import uuid\n",
     "session_id:str = str(uuid.uuid1())\n",
-    "query = \"What are the starters in the childrens menu?\"\n",
+    "query = \"What are the entrees in the childrens menu?\"\n",
     "response = invoke_agent_helper(query, session_id, agent_id, alias_id)\n",
     "print(response)"
    ]

--- a/05_Agents/agent.py
+++ b/05_Agents/agent.py
@@ -181,7 +181,7 @@ def invoke_agent_helper(query, session_id, agent_id, alias_id, enable_trace=Fals
                 # End event indicates that the request finished successfully
             elif 'trace' in event:
                 if enable_trace:
-                    logger.info(json.dumps(event['trace'], indent=2))
+                    logger.info(json.dumps(event['trace'], indent=2, default=str))
             else:
                 raise Exception("unexpected event.", event)
     except Exception as e:


### PR DESCRIPTION
*Description of changes:*

Aligned the agent tests to the provided data to avoid confusion in response.
Invoke agent with trace enabled now print the log serializing non-default serializable objects

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
