### PR TITLE
fix warning on The class `AmazonKnowledgeBasesRetriever`

### DIFF
--- a/02_KnowledgeBases_and_RAG/3_Langchain-rag-retrieve-api-claude-3.ipynb
+++ b/02_KnowledgeBases_and_RAG/3_Langchain-rag-retrieve-api-claude-3.ipynb
@@ -328,7 +328,7 @@
    "outputs": [],
    "source": [
     "from langchain_aws import ChatBedrock\n",
-    "from langchain.retrievers.bedrock import AmazonKnowledgeBasesRetriever\n",
+    "from langchain_aws import AmazonKnowledgeBasesRetriever\n",
     "\n",
     "llm = ChatBedrock(model_id=modelId, \n",
     "                  client=bedrock_client)"


### PR DESCRIPTION
The class `AmazonKnowledgeBasesRetriever` was deprecated in LangChain 0.3.16 and will be removed in 1.0. 

*Issue #, if available:* warning on decprecated LangChain

*Description of changes:*

   delete "from langchain.retrievers.bedrock import AmazonKnowledgeBasesRetriever\n",
    change to "from langchain_aws import AmazonKnowledgeBasesRetriever\n",
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
