### PR TITLE
Specify us-east-1 as the region for the nova-reel-notebook

### DIFF
--- a/04_Image_and_Multimodal/nova-reel-notebook.ipynb
+++ b/04_Image_and_Multimodal/nova-reel-notebook.ipynb
@@ -88,7 +88,7 @@
     "\n",
     "account_id = boto3.client('sts').get_caller_identity().get('Account')\n",
     "\n",
-    "bedrock_runtime = boto3.client('bedrock-runtime')\n",
+    "bedrock_runtime = boto3.client('service_name='bedrock-runtime',region_name='us-east-1')\n",
     "s3_bucket = f\"video-bucket-{account_id}\"\n",
     "local_output_folder = \"output\""
    ]


### PR DESCRIPTION
*Issue #, if available:*
Nova-reel isn't available in the us-west-2 region hosting the workshop. 

*Description of changes:*
In the nova-reel notebook, I am specifying the region as us-east-1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
