### PR TITLE
Update default region to us-east-1 in LangGraph examples

### DIFF
--- a/06_OpenSource_examples/simple-langgraph-agent-setup.ipynb
+++ b/06_OpenSource_examples/simple-langgraph-agent-setup.ipynb
@@ -189,7 +189,7 @@
     "from langchain_core.runnables.config import RunnableConfig\n",
     "from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder\n",
     "\n",
-    "bedrock_client = boto3.client(\"bedrock-runtime\", region_name=\"us-west-2\")\n",
+    "bedrock_client = boto3.client(\"bedrock-runtime\", region_name=\"us-east-1\")\n",
     "model_id = \"us.amazon.nova-lite-v1:0\"\n",
     "provider_id = \"amazon\"\n",
     "\n",
@@ -769,7 +769,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-02-13T20:33:39.439454Z",
@@ -783,7 +783,7 @@
     "from langchain_core.runnables.history import RunnableWithMessageHistory\n",
     "\n",
     "\n",
-    "bedrock_client = boto3.client(\"bedrock-runtime\", region_name=\"us-west-2\")\n",
+    "bedrock_client = boto3.client(\"bedrock-runtime\", region_name=\"us-east-1\")\n",
     "model_id = \"us.amazon.nova-micro-v1:0\"\n",
     "\n",
     "provider_id = \"amazon\"\n",


### PR DESCRIPTION
This PR updates the default AWS region from us-west-2 to us-east-1 in the LangGraph agent setup notebook to align with the default region used in AWS Workshop Studio. This change ensures a more consistent experience for workshop participants by eliminating region mismatches between the workshop environment and the code examples.

Changes:
- Updated boto3 client initialization to use us-east-1 instead of us-west-2 in two locations

