### PR TITLE
Update default region from us-west-2 to us-east-1 in RAG example

### DIFF
--- a/06_OpenSource_examples/find-relevant-information-using-RAG.ipynb
+++ b/06_OpenSource_examples/find-relevant-information-using-RAG.ipynb
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "3c95bebf-c30b-47a3-8566-438275fe37da",
    "metadata": {
     "ExecuteTime": {
@@ -102,7 +102,7 @@
    },
    "outputs": [],
    "source": [
-    "region = 'us-west-2'\n",
+    "region = 'us-east-1'\n",
     "bedrock = boto3.client(\n",
     "    service_name = 'bedrock-runtime',\n",
     "    region_name = region,\n",


### PR DESCRIPTION
Description:
This PR updates the default AWS region from us-west-2 to us-east-1 in the find-
relevant-information-using-RAG notebook to align with the default region used in
AWS Workshop Studio. This change ensures a more consistent experience for
workshop participants by eliminating region mismatches between the workshop
environment and the code examples.

Changes:
• Updated region variable from 'us-west-2' to 'us-east-1'
