### PR TITLE
BUG FIX: fixed the get_named_parameter function to properly handle th…

### DIFF
--- a/05_Agents/01_create_agent.ipynb
+++ b/05_Agents/01_create_agent.ipynb
@@ -316,7 +316,7 @@
     "    \"\"\"\n",
     "    Get a parameter from the lambda event\n",
     "    \"\"\"\n",
-    "    return next(item for item in event['parameters'] if item['name'] == name)['value']\n",
+    "    return next((item for item in event['parameters'] if item['name'] == name),{}).get('value', None))\n",
     "\n",
     "\n",
     "def get_booking_details(booking_id):\n",


### PR DESCRIPTION
…e case where the parameter is not found in the event object.

*Issue #, if available:*

*Description of changes:*
In `lambda_handler()` when calling `get_named_parameter()` its considered as best case that "booking_id" will exists. If it does not `next()` will raise `stopIteration` exception leading further failure. Changes made to avoid stopIteration exception and provide `NONE` when correct key does not exists.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
