### PR TITLE
docs: fix broken links #366 and add missing dependency #368

### DIFF
--- a/05-Agents/requirements.txt
+++ b/05-Agents/requirements.txt
@@ -6,3 +6,4 @@ boto3
 botocore
 opensearch-py
 uv
+langchain-aws

--- a/07_Cross_Region_Inference/Getting_started_with_Cross-region_Inference.ipynb
+++ b/07_Cross_Region_Inference/Getting_started_with_Cross-region_Inference.ipynb
@@ -463,7 +463,7 @@
     "    model_kwargs=model_parameter, \n",
     "    beta_use_converse_api=True,  \n",
     "    client=bedrock_runtime,\n",
-    "    region_name='us-east-1'\n",
+    "    \n",
     ")\n",
     "print(llm.invoke(messages).content)"
    ]
@@ -498,7 +498,7 @@
     "    #model_kwargs=model_parameter,\n",
     "    beta_use_converse_api=True,\n",
     "    client=bedrock_runtime,\n",
-    "    region_name='us-east-1'\n",
+    "    \n",
     ")\n",
     "# - these will take precedence even if we have similiar params when creating the class\n",
     "runtime_parameter = {\"temperature\": 0.9,  \"max_tokens\": 100 }\n",
@@ -535,7 +535,7 @@
     "    model_kwargs=model_parameter,\n",
     "    beta_use_converse_api=True,\n",
     "    client=bedrock_runtime,\n",
-    "    region_name='us-east-1'\n",
+    "\n",
     ")\n",
     "\n",
     "# These would take precedence \n",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Amazon Bedrock Workshop [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/dwyl/esta/issues)
 
-This hands-on workshop, aimed at developers and solution builders, introduces how to leverage foundation models (FMs) through [Amazon Bedrock](https://aws.amazon.com/bedrock/). This code goes alongside the self-paced or instructor lead workshop here - https://catalog.us-east-1.prod.workshops.aws/amazon-bedrock/en-US
+This hands-on workshop, aimed at developers and solution builders, introduces how to leverage foundation models (FMs) through [Amazon Bedrock](https://aws.amazon.com/bedrock/). This code goes alongside the self-paced or instructor lead workshop here - https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization.html
 
 **Please follow the prerequisites listed in the link above or ask your AWS workshop instructor how to get started.**
 
@@ -39,7 +39,7 @@ Labs include:
 
 </div>
 
-You can also refer to these [Step-by-step guided instructions on the workshop website](https://catalog.us-east-1.prod.workshops.aws/workshops/a4bdb007-5600-4368-81c5-ff5b4154f518/en-US).
+You can also refer to these [Step-by-step guided instructions on the workshop website] https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization.html
 
 
 ## Getting started


### PR DESCRIPTION
*Issue #, if available:*
## Description
This PR addresses two open issues found in the Amazon Bedrock Workshop repository to improve the developer onboarding experience.

*Description of changes:*
** Updated broken Workshop Studio links in the `03_Model_customization` README. These links were previously leading to 404/internal pages. They now point to the official Amazon Bedrock Model Customization documentation.
** Added `langchain-aws` to the `requirements.txt` in the `05_Agents` folder. This resolves the `ModuleNotFoundError` reported when attempting to run the inline agents notebooks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
