### PR TITLE
Fix AWS region to us-west-2 in agents notebook

### DIFF
--- a/04_Agents/05_agents.ipynb
+++ b/04_Agents/05_agents.ipynb
@@ -252,21 +252,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "import os\n",
-    "from utils import utils\n",
-    "from strands_tools import retrieve\n",
-    "\n",
-    "kb_name = \"restaurant-assistant\"\n",
-    "kb_id = utils.get_kb_id(kb_name=kb_name)\n",
-    "\n",
-    "# Set default variables required for Strands Agents retrieve tool\n",
-    "os.environ[\"KNOWLEDGE_BASE_ID\"] = kb_id\n",
-    "os.environ['AWS_REGION'] = 'us-east-1'\n",
-    "\n",
-    "agent = Agent(model=model, tools=[current_time, retrieve])\n",
-    "results = agent(\"Hi, can you check in the knowledge base what restaurants are in San Francisco?\")"
-   ]
+   "source": "import os\nfrom utils import utils\nfrom strands_tools import retrieve\n\nkb_name = \"restaurant-assistant\"\nkb_id = utils.get_kb_id(kb_name=kb_name)\n\n# Set default variables required for Strands Agents retrieve tool\nos.environ[\"KNOWLEDGE_BASE_ID\"] = kb_id\nos.environ['AWS_REGION'] = 'us-west-2'\n\nagent = Agent(model=model, tools=[current_time, retrieve])\nresults = agent(\"Hi, can you check in the knowledge base what restaurants are in San Francisco?\")"
   },
   {
    "cell_type": "markdown",
@@ -900,17 +886,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "launch_result = agentcore_runtime.launch(\n",
-    "    env_vars={\n",
-    "        \"KNOWLEDGE_BASE_ID\": kb_id,\n",
-    "        \"KNOWLEDGE_BASE_NAME\": kb_name,\n",
-    "        \"DB_TABLE_NAME\": db_table_name,\n",
-    "        \"BEDROCK_MODEL_ID\": \"us.amazon.nova-2-lite-v1:0\",  \n",
-    "        \"BEDROCK_MODEL_SYSTEM_PROMPT\": system_prompt\n",
-    "    }\n",
-    ")"
-   ]
+   "source": "launch_result = agentcore_runtime.launch(\n    env_vars={\n        \"KNOWLEDGE_BASE_ID\": kb_id,\n        \"KNOWLEDGE_BASE_NAME\": kb_name,\n        \"DB_TABLE_NAME\": db_table_name,\n        \"BEDROCK_MODEL_ID\": \"us.amazon.nova-2-lite-v1:0\",  \n        \"BEDROCK_MODEL_SYSTEM_PROMPT\": system_prompt,\n        \"AWS_REGION\": \"us-west-2\"\n    }\n)"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
*Description of changes in the Agent notebook:*
- Changed os.environ['AWS_REGION'] from us-east-1 to us-west-2 for local agent testing
- Added "AWS_REGION": "us-west-2" to the agentcore_runtime.launch() env_vars for AgentCore deployment so that the region gets picked by the "Retrieve" tool

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
